### PR TITLE
Allow the Teiid DDL sequencer to be extended

### DIFF
--- a/sequencers/teiid-modeshape-sequencer-ddl/src/main/java/org/teiid/modeshape/sequencer/ddl/TeiidDdlSequencer.java
+++ b/sequencers/teiid-modeshape-sequencer-ddl/src/main/java/org/teiid/modeshape/sequencer/ddl/TeiidDdlSequencer.java
@@ -32,7 +32,7 @@ import org.modeshape.jcr.api.sequencer.Sequencer;
 /**
  * A {@link Sequencer sequencer} for Teiid DDL.
  */
-public final class TeiidDdlSequencer extends DdlSequencer {
+public class TeiidDdlSequencer extends DdlSequencer {
 
 	private static final String[] GRAMMARS = new String[] { TeiidDdlParser.ID };
 


### PR DESCRIPTION
 Removed the "final" modifier in the class TeiidDdlSequencer. This will allow the KDdlSequencer, or any other sequencer, to extend the Teiid DDL sequencer.