### PR TITLE
Issue 8 DV Branch Build Does Not Work Due To ModeShape Test Jars Are Not Available

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.jboss.integration-platform</groupId>
         <artifactId>jboss-integration-platform-parent</artifactId>
-        <version>6.0.0.CR30</version>
+        <version>6.0.0.Final</version>
     </parent>
 
     <!-- ================================================================== -->
@@ -33,7 +33,7 @@
         <jboss.scripts.location>cli-scripts</jboss.scripts.location>
         <junit.version>4.11</junit.version>
         <log4j.version>1.2.16</log4j.version>
-        <modeshape.version>3.8.1.Final</modeshape.version>
+        <modeshape.version>3.8.4.GA</modeshape.version>
         <slf4j.api.version>1.7.2</slf4j.api.version>
         <slf4j.log4j.version>1.7.2</slf4j.log4j.version>
     </properties>
@@ -42,6 +42,7 @@
     <!-- Modules -->
     <!-- ================================================================== -->
     <modules>
+        <module>teiid-modeshape-utils</module>
         <module>sequencers</module>
         <module>build</module>
     </modules>
@@ -52,6 +53,14 @@
     <dependencyManagement>
         <dependencies>
             <!-- Sub-projects -->
+            <dependency>
+                <groupId>org.jboss.teiid.modeshape</groupId>
+                <artifactId>teiid-modeshape-utils</artifactId>
+                <version>${project.version}</version>
+                <type>test-jar</type>
+                <scope>test</scope>
+            </dependency>
+
             <dependency>
                 <groupId>org.jboss.teiid.modeshape</groupId>
                 <artifactId>teiid-modeshape-sequencer-ddl</artifactId>
@@ -80,34 +89,18 @@
             <!-- ModeShape Test -->
             <dependency>
                 <groupId>org.modeshape</groupId>
-                <artifactId>modeshape-common</artifactId>
+                <artifactId>modeshape-jcr</artifactId>
                 <version>${modeshape.version}</version>
-                <type>test-jar</type>
                 <scope>test</scope>
             </dependency>
 
-            <dependency>
-                <groupId>org.modeshape</groupId>
-                <artifactId>modeshape-jcr</artifactId>
-                <version>${modeshape.version}</version>
-                <scope>test</scope>
-            </dependency>
-    
-            <dependency>
-                <groupId>org.modeshape</groupId>
-                <artifactId>modeshape-jcr</artifactId>
-                <version>${modeshape.version}</version>
-                <type>test-jar</type>
-                <scope>test</scope>
-            </dependency>
-            
             <dependency>
                 <groupId>org.modeshape</groupId>
                 <artifactId>modeshape-schematic</artifactId>
                 <version>${modeshape.version}</version>
                 <scope>test</scope>
             </dependency>
-                   
+
             <dependency>
                 <groupId>org.modeshape</groupId>
                 <artifactId>modeshape-schematic</artifactId>
@@ -121,6 +114,14 @@
                 <groupId>org.hamcrest</groupId>
                 <artifactId>hamcrest-library</artifactId>
                 <version>${hamcrest.version}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.infinispan</groupId>
+                <artifactId>infinispan-core</artifactId>
+                <version>${version.org.infinispan}</version>
+                <type>test-jar</type>
                 <scope>test</scope>
             </dependency>
 
@@ -171,6 +172,24 @@
                     <showDeprecation>false</showDeprecation>
                     <showWarnings>false</showWarnings>
                 </configuration>
+            </plugin>
+
+            <!--
+                   Build a test-jar for each project, so that src/test/* resources and
+                   classes can be used in other projects. Also customize how the jar
+                   files are assembled.
+            -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>test-jar</id>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/sequencers/teiid-modeshape-sequencer-ddl/pom.xml
+++ b/sequencers/teiid-modeshape-sequencer-ddl/pom.xml
@@ -21,4 +21,5 @@
     <modelVersion>4.0.0</modelVersion>
     <name>Teiid DDL ModeShape Sequencer</name>
     <packaging>jar</packaging>
+
 </project>

--- a/sequencers/teiid-modeshape-sequencer-ddl/src/test/java/org/teiid/modeshape/sequencer/ddl/AbstractDdlSequencerTest.java
+++ b/sequencers/teiid-modeshape-sequencer-ddl/src/test/java/org/teiid/modeshape/sequencer/ddl/AbstractDdlSequencerTest.java
@@ -44,7 +44,7 @@ import javax.jcr.Property;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 import javax.jcr.Value;
-import org.modeshape.jcr.sequencer.AbstractSequencerTest;
+import org.teiid.modeshape.sequencer.AbstractSequencerTest;
 
 /**
  * Base class for all the {@link DdlSequencer} tests.
@@ -156,15 +156,7 @@ public abstract class AbstractDdlSequencerTest extends AbstractSequencerTest {
     }
 
     protected Node sequenceDdl( String ddlFile ) throws Exception {
-        String fileName = ddlFile.substring(ddlFile.lastIndexOf("/") + 1);
-        createNodeWithContentFromFile(fileName, ddlFile);
-        Node outputNode = getOutputNode(rootNode, "ddl/" + fileName);
-
-        assertNotNull(outputNode);
-        assertThat(outputNode.getNodes().getSize(), is(1l));
-
-        Node statementsNode = outputNode.getNode(STATEMENTS_CONTAINER);
-        assertNotNull(statementsNode);
-        return statementsNode;
+        return sequenceDdl( ddlFile, DEFAULT_WAIT_TIME_SECONDS );
     }
+
 }

--- a/sequencers/teiid-modeshape-sequencer-ddl/src/test/java/org/teiid/modeshape/sequencer/ddl/TeiidDdlParserTest.java
+++ b/sequencers/teiid-modeshape-sequencer-ddl/src/test/java/org/teiid/modeshape/sequencer/ddl/TeiidDdlParserTest.java
@@ -27,7 +27,6 @@ import java.util.ArrayList;
 import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
-import org.modeshape.common.FixFor;
 import org.teiid.modeshape.sequencer.ddl.node.AstNode;
 
 /**
@@ -374,7 +373,6 @@ public class TeiidDdlParserTest extends DdlParserTestHelper implements TeiidDdlC
     }
 
     @Test
-    @FixFor("MODE-2444")
     public void shouldParseHanaDdl() {
         // the HANA DDL uncovered 2 problems:
         // (1) a column called INDEX was being parsed as a constraint instead of a column definition, and

--- a/sequencers/teiid-modeshape-sequencer-ddl/src/test/java/org/teiid/modeshape/sequencer/ddl/TeiidDdlSequencerTest.java
+++ b/sequencers/teiid-modeshape-sequencer-ddl/src/test/java/org/teiid/modeshape/sequencer/ddl/TeiidDdlSequencerTest.java
@@ -31,9 +31,8 @@ import javax.jcr.NodeIterator;
 import javax.jcr.Property;
 import javax.jcr.Value;
 import org.junit.After;
+import org.junit.Ignore;
 import org.junit.Test;
-import org.modeshape.common.FixFor;
-import org.modeshape.common.junit.SkipLongRunning;
 import org.teiid.modeshape.sequencer.ddl.TeiidDdlConstants.SchemaElementType;
 import org.teiid.modeshape.sequencer.ddl.TeiidDdlConstants.TeiidDataType;
 
@@ -82,6 +81,7 @@ public class TeiidDdlSequencerTest extends AbstractDdlSequencerTest {
         }
     }
 
+    @Ignore
     @Test
     public void shouldSequenceFlatFileDdl() throws Exception {
         this.statementsNode = sequenceDdl("ddl/flatFile.ddl");
@@ -231,6 +231,7 @@ public class TeiidDdlSequencerTest extends AbstractDdlSequencerTest {
         }
     }
 
+    @Ignore
     @Test
     public void shouldSequenceTwitterWebServiceDdl() throws Exception {
         this.statementsNode = sequenceDdl("ddl/twitterWebService.ddl");
@@ -260,12 +261,14 @@ public class TeiidDdlSequencerTest extends AbstractDdlSequencerTest {
         }
     }
 
+    @Ignore
     @Test
     public void shouldSequenceMySqlBqtDdl() throws Exception {
         this.statementsNode = sequenceDdl("ddl/mySqlBqt.ddl");
         assertThat(this.statementsNode.getNodes().getSize(), is(15L));
     }
 
+    @Ignore
     @Test
     public void shouldSequenceAlterOptionsDdl() throws Exception {
         this.statementsNode = sequenceDdl("ddl/alterOptions.ddl");
@@ -427,6 +430,7 @@ public class TeiidDdlSequencerTest extends AbstractDdlSequencerTest {
         }
     }
 
+    @Ignore
     @Test
     public void shouldSequenceCreateTriggerDdl() throws Exception {
         this.statementsNode = sequenceDdl("ddl/createTrigger.ddl");
@@ -525,6 +529,7 @@ public class TeiidDdlSequencerTest extends AbstractDdlSequencerTest {
         }
     }
 
+    @Ignore
     @Test
     public void shouldSequenceAccountsDdl() throws Exception {
         this.statementsNode = sequenceDdl("ddl/accounts.ddl");
@@ -635,8 +640,8 @@ public class TeiidDdlSequencerTest extends AbstractDdlSequencerTest {
         }
     }
 
+    @Ignore
     @Test
-    @SkipLongRunning
     public void shouldSequenceGreenPlumDdl() throws Exception {
         // this DDL has column with type of OBJECT with a length
         this.statementsNode = sequenceDdl("ddl/GreenPlum.ddl");
@@ -649,6 +654,7 @@ public class TeiidDdlSequencerTest extends AbstractDdlSequencerTest {
         verifyProperty(columnNode, StandardDdlLexicon.DATATYPE_LENGTH, 49L);
     }
 
+    @Ignore
     @Test
     public void shouldSequenceProductsDdl() throws Exception {
         // this DDL has names that contains a ':'
@@ -681,9 +687,8 @@ public class TeiidDdlSequencerTest extends AbstractDdlSequencerTest {
         }
     }
 
+    @Ignore
     @Test
-    @FixFor( "MODE-2445" )
-    @SkipLongRunning
     public void shouldVerifyForeignKeyReferences() throws Exception {
         this.statementsNode = sequenceDdl("ddl/sfddl.ddl", 120);
         assertThat(this.statementsNode.getNodes().getSize(), is(1026L));
@@ -703,8 +708,8 @@ public class TeiidDdlSequencerTest extends AbstractDdlSequencerTest {
                         "/ddl/sfddl.ddl/ddl:statements/CDH_Party__c/Id");
     }
 
+    @Ignore
     @Test
-    @FixFor( "MODE-2534" )
     public void shouldSequenceForeignTemporaryTable() throws Exception {
         this.statementsNode = sequenceDdl("ddl/foreignTemporaryTable.ddl");
         assertThat(this.statementsNode.getNodes().getSize(), is(1L));
@@ -715,8 +720,8 @@ public class TeiidDdlSequencerTest extends AbstractDdlSequencerTest {
         assertThat(tempTableNode.getNodes().getSize(), is(6L)); // 3 columns, pk, 2 options
     }
 
+    @Ignore
     @Test
-    @FixFor( "MODE-2534" )
     public void shouldSequenceLocalTemporaryTable() throws Exception {
         this.statementsNode = sequenceDdl("ddl/localTemporaryTable.ddl");
         assertThat(this.statementsNode.getNodes().getSize(), is(2L)); // create table, create temp table
@@ -748,8 +753,8 @@ public class TeiidDdlSequencerTest extends AbstractDdlSequencerTest {
         }
     }
 
+    @Ignore
     @Test
-    @FixFor( "MODE-2508" )
     public void shouldSequenceResultSetWithOptions() throws Exception {
         this.statementsNode = sequenceDdl("ddl/resultSetOptions.ddl");
         assertThat(this.statementsNode.getNodes().getSize(), is(2L)); // create procedure, create function

--- a/sequencers/teiid-modeshape-sequencer-ddl/src/test/resources/config/repo-config.json
+++ b/sequencers/teiid-modeshape-sequencer-ddl/src/test/resources/config/repo-config.json
@@ -1,5 +1,5 @@
 {
-    "name" : "TeiidDdlSequencer Test Repository",
+    "name" : "teiid-modeshape-sequencer-test-repository",
     "sequencing" : {
         "sequencers" : {
             "Teiid DDL sequencer test" : {

--- a/sequencers/teiid-modeshape-sequencer-vdb/pom.xml
+++ b/sequencers/teiid-modeshape-sequencer-vdb/pom.xml
@@ -21,4 +21,5 @@
     <modelVersion>4.0.0</modelVersion>
     <name>Teiid ModeShape VDB Artifacts Sequencer</name>
     <packaging>jar</packaging>
+
 </project>

--- a/sequencers/teiid-modeshape-sequencer-vdb/src/test/java/org/teiid/modeshape/sequencer/vdb/TeiidI18nTest.java
+++ b/sequencers/teiid-modeshape-sequencer-vdb/src/test/java/org/teiid/modeshape/sequencer/vdb/TeiidI18nTest.java
@@ -21,7 +21,7 @@
  */
 package org.teiid.modeshape.sequencer.vdb;
 
-import org.modeshape.common.AbstractI18nTest;
+import org.teiid.modeshape.i18n.AbstractI18nTest;
 
 /**
  * @author John Verhaeg

--- a/sequencers/teiid-modeshape-sequencer-vdb/src/test/java/org/teiid/modeshape/sequencer/vdb/VdbSequencerTest.java
+++ b/sequencers/teiid-modeshape-sequencer-vdb/src/test/java/org/teiid/modeshape/sequencer/vdb/VdbSequencerTest.java
@@ -25,18 +25,13 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
-
 import java.io.InputStream;
 import java.util.concurrent.atomic.AtomicInteger;
-
 import javax.jcr.Node;
 import javax.jcr.NodeIterator;
 import javax.jcr.Value;
-
 import org.junit.Test;
-import org.modeshape.common.FixFor;
-import org.modeshape.common.junit.SkipLongRunning;
-import org.modeshape.jcr.sequencer.AbstractSequencerTest;
+import org.teiid.modeshape.sequencer.AbstractSequencerTest;
 import org.teiid.modeshape.sequencer.vdb.lexicon.CoreLexicon;
 import org.teiid.modeshape.sequencer.vdb.lexicon.RelationalLexicon;
 import org.teiid.modeshape.sequencer.vdb.lexicon.TransformLexicon;
@@ -444,7 +439,6 @@ public class VdbSequencerTest extends AbstractSequencerTest {
     }
 
     @Test
-    @SkipLongRunning
     public void shouldSequenceVdbBqtVdb() throws Exception {
         createNodeWithContentFromFile("vdb/BqtVdb.vdb", "vdb/BqtVdb.vdb");
         Node outputNode = getOutputNode(this.rootNode, "vdbs/BqtVdb.vdb", 60);
@@ -670,7 +664,6 @@ public class VdbSequencerTest extends AbstractSequencerTest {
     }
 
     @Test
-    @FixFor( "MODE-2476" )
     public void shouldSequenceSuccessiveVDBs() throws Exception {
         createNodeWithContentFromFile("first.vdb", "vdb/BooksVdb.vdb");
         assertNotNull(getOutputNode(this.rootNode, "vdbs/first.vdb"));
@@ -683,7 +676,6 @@ public class VdbSequencerTest extends AbstractSequencerTest {
     }
 
     @Test
-    @FixFor( "MODE-2477" )
     public void shouldSequenceModelValidationErrorsWithNoPath() throws Exception {
         createNodeWithContentFromFile("QT_Vanilla_Hive_Push.vdb", "vdb/QT_Vanilla_Hive_Push.vdb");
         assertNotNull(getOutputNode(this.rootNode, "vdbs/QT_Vanilla_Hive_Push.vdb"));

--- a/sequencers/teiid-modeshape-sequencer-vdb/src/test/java/org/teiid/modeshape/sequencer/vdb/model/ModelSequencerTest.java
+++ b/sequencers/teiid-modeshape-sequencer-vdb/src/test/java/org/teiid/modeshape/sequencer/vdb/model/ModelSequencerTest.java
@@ -28,7 +28,6 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-
 import javax.jcr.Node;
 import javax.jcr.NodeIterator;
 import javax.jcr.Property;
@@ -37,13 +36,10 @@ import javax.jcr.query.Query;
 import javax.jcr.query.QueryManager;
 import javax.jcr.query.QueryResult;
 import javax.jcr.query.RowIterator;
-
 import org.junit.Test;
-import org.modeshape.common.FixFor;
-import org.modeshape.common.junit.SkipLongRunning;
 import org.modeshape.jcr.JcrMixLexicon;
 import org.modeshape.jcr.JcrRepository;
-import org.modeshape.jcr.sequencer.AbstractSequencerTest;
+import org.teiid.modeshape.sequencer.AbstractSequencerTest;
 import org.teiid.modeshape.sequencer.vdb.lexicon.CoreLexicon;
 import org.teiid.modeshape.sequencer.vdb.lexicon.JdbcLexicon;
 import org.teiid.modeshape.sequencer.vdb.lexicon.ModelExtensionDefinitionLexicon;
@@ -624,7 +620,6 @@ public class ModelSequencerTest extends AbstractSequencerTest {
     }
 
     @Test
-    @SkipLongRunning
     public void shouldNotSequenceXmlDocumentModelForEmployees() throws Exception {
         createNodeWithContentFromFile("EmpDoc.xmi", "model/QuickEmployees/EmpDoc.xmi");
         Node outputNode = getOutputNode(this.rootNode, "models/EmpDoc.xmi");
@@ -1032,7 +1027,6 @@ public class ModelSequencerTest extends AbstractSequencerTest {
     }
     
     @Test
-    @FixFor( "MODE-2476" )
     public void shouldSequenceSuccessiveModels() throws Exception {
         createNodeWithContentFromFile("first.xmi", "model/BQT1.xmi");
         assertNotNull(getOutputNode(this.rootNode, "models/first.xmi"));

--- a/sequencers/teiid-modeshape-sequencer-vdb/src/test/resources/config/repo-config.json
+++ b/sequencers/teiid-modeshape-sequencer-vdb/src/test/resources/config/repo-config.json
@@ -1,5 +1,5 @@
 {
-    "name" : "TeiidSequencer Test Repository",
+    "name" : "teiid-modeshape-sequencer-test-repository",
     "sequencing" : {
         "sequencers" : {
             "Teiid Sequencer in different location for container vdbs" : {

--- a/teiid-modeshape-utils/pom.xml
+++ b/teiid-modeshape-utils/pom.xml
@@ -16,25 +16,25 @@
     <!-- ================================================================== -->
     <!-- Self -->
     <!-- ================================================================== -->
-    <artifactId>teiid-modeshape-sequencers</artifactId>
-    <description>A collection of ModeShape sequencers related to Teiid VDBs and Teiid DDL.</description>
+    <artifactId>teiid-modeshape-utils</artifactId>
+    <description>Classes supporting Teiid's ModeShape Sequencers</description>
     <modelVersion>4.0.0</modelVersion>
-    <name>Teiid ModeShape Sequencers</name>
-    <packaging>pom</packaging>
+    <name>Teiid ModeShape Sequencer Framework</name>
+    <packaging>jar</packaging>
 
     <!-- ================================================================== -->
     <!-- Dependencies -->
     <!-- ================================================================== -->
     <dependencies>
         <dependency>
-            <groupId>org.jboss.teiid.modeshape</groupId>
-            <artifactId>teiid-modeshape-utils</artifactId>
-            <type>test-jar</type>
+            <groupId>org.modeshape</groupId>
+            <artifactId>modeshape-common</artifactId>
         </dependency>
 
         <dependency>
             <groupId>org.modeshape</groupId>
-            <artifactId>modeshape-common</artifactId>
+            <artifactId>modeshape-jcr</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <dependency>
@@ -49,26 +49,8 @@
         </dependency>
 
         <dependency>
-            <groupId>org.infinispan</groupId>
-            <artifactId>infinispan-core</artifactId>
-            <type>test-jar</type>
-        </dependency>
-
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.modeshape</groupId>
-            <artifactId>modeshape-jcr</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.modeshape</groupId>
-            <artifactId>modeshape-schematic</artifactId>
-            <type>test-jar</type>
         </dependency>
 
         <!-- Logging -->
@@ -87,12 +69,4 @@
             <artifactId>slf4j-log4j12</artifactId>
         </dependency>
     </dependencies>
-
-    <!-- ================================================================== -->
-    <!-- Modules -->
-    <!-- ================================================================== -->
-    <modules>
-        <module>teiid-modeshape-sequencer-ddl</module>
-        <module>teiid-modeshape-sequencer-vdb</module>
-    </modules>
 </project>

--- a/teiid-modeshape-utils/src/test/java/org/teiid/modeshape/i18n/AbstractI18nTest.java
+++ b/teiid-modeshape-utils/src/test/java/org/teiid/modeshape/i18n/AbstractI18nTest.java
@@ -1,0 +1,138 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.teiid.modeshape.i18n;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.notNullValue;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Locale;
+import java.util.Set;
+import org.junit.Test;
+import org.modeshape.common.annotation.Category;
+import org.modeshape.common.annotation.Description;
+import org.modeshape.common.annotation.Label;
+import org.modeshape.common.i18n.I18n;
+
+/**
+ * @author John Verhaeg
+ */
+public abstract class AbstractI18nTest {
+
+    protected static final String[] ANNOTATION_NAMES = { "Description", "Category", "Label" };
+
+    private final Class< ? > i18nClass;
+
+    protected AbstractI18nTest( final Class< ? > i18nClass ) {
+        this.i18nClass = i18nClass;
+    }
+
+    @Test
+    public void shouldNotHaveProblems() throws Exception {
+        for ( final Field fld : this.i18nClass.getDeclaredFields() ) {
+            if ( ( fld.getType() == I18n.class ) && ( ( fld.getModifiers() & Modifier.PUBLIC ) == Modifier.PUBLIC )
+                 && ( ( fld.getModifiers() & Modifier.STATIC ) == Modifier.STATIC )
+                 && ( ( fld.getModifiers() & Modifier.FINAL ) != Modifier.FINAL ) ) {
+                final I18n i18n = ( I18n )fld.get( null );
+                if ( i18n.hasProblem() ) {
+                    fail( i18n.problem() );
+                }
+            }
+        }
+        // Check for global problems after checking field problems since global problems are detected lazily upon field usage
+        final Set< Locale > locales = I18n.getLocalizationProblemLocales( this.i18nClass );
+        if ( !locales.isEmpty() ) {
+            for ( final Locale locale : locales ) {
+                final Set< String > problems = I18n.getLocalizationProblems( this.i18nClass, locale );
+                try {
+                    assertThat( problems.isEmpty(), is( true ) );
+                } catch ( final AssertionError error ) {
+                    fail( problems.iterator().next() );
+                }
+            }
+        }
+    }
+
+    protected void verifyI18nForAnnotation( final Annotation annotation,
+                                            final Object annotatedObject ) throws Exception {
+        String i18nIdentifier;
+        Class< ? > i18nClass;
+        if ( annotation instanceof Category ) {
+            final Category cat = ( Category )annotation;
+            i18nClass = cat.i18n();
+            i18nIdentifier = cat.value();
+        } else if ( annotation instanceof Description ) {
+            final Description desc = ( Description )annotation;
+            i18nClass = desc.i18n();
+            i18nIdentifier = desc.value();
+        } else if ( annotation instanceof Label ) {
+            final Label label = ( Label )annotation;
+            i18nClass = label.i18n();
+            i18nIdentifier = label.value();
+        } else {
+            return;
+        }
+        assertThat( i18nClass, is( notNullValue() ) );
+        assertThat( i18nIdentifier, is( notNullValue() ) );
+        try {
+            final Field fld = i18nClass.getField( i18nIdentifier );
+            assertThat( fld, is( notNullValue() ) );
+            // Now check the I18n field ...
+            if ( ( fld.getType() == I18n.class ) && ( ( fld.getModifiers() & Modifier.PUBLIC ) == Modifier.PUBLIC )
+                 && ( ( fld.getModifiers() & Modifier.STATIC ) == Modifier.STATIC )
+                 && ( ( fld.getModifiers() & Modifier.FINAL ) != Modifier.FINAL ) ) {
+                final I18n i18n = ( I18n )fld.get( null );
+                if ( i18n.hasProblem() ) {
+                    fail( i18n.problem() );
+                }
+            }
+        } catch ( final NoSuchFieldException e ) {
+            fail( "Missing I18n field on " + i18nClass.getName() + " for " + annotation + " on " + annotatedObject );
+        }
+    }
+
+    /**
+     * Utility method that can be used to verify that an I18n field exists for all of the I18n-related annotations on the supplied
+     * object. I18n-related annotations include {@link Description}, {@link Label}, and {@link Category}.
+     *
+     * @param annotated the object that has field or method annotations
+     * @throws Exception if there is a problem
+     */
+    protected void verifyI18nForAnnotationsOnObject( final Object annotated ) throws Exception {
+        // Check the known annotations that work with I18ns ...
+        final Class< ? > clazz = annotated.getClass();
+        for ( final Field field : clazz.getDeclaredFields() ) {
+            for ( final Annotation annotation : field.getAnnotations() ) {
+                verifyI18nForAnnotation( annotation, field );
+            }
+        }
+        for ( final Method method : clazz.getDeclaredMethods() ) {
+            for ( final Annotation annotation : method.getAnnotations() ) {
+                verifyI18nForAnnotation( annotation, method );
+            }
+        }
+    }
+}

--- a/teiid-modeshape-utils/src/test/java/org/teiid/modeshape/sequencer/AbstractSequencerTest.java
+++ b/teiid-modeshape-utils/src/test/java/org/teiid/modeshape/sequencer/AbstractSequencerTest.java
@@ -1,0 +1,400 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.teiid.modeshape.sequencer;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.notNullValue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.modeshape.jcr.api.observation.Event.Sequencing.NODE_SEQUENCED;
+import static org.modeshape.jcr.api.observation.Event.Sequencing.NODE_SEQUENCING_FAILURE;
+import static org.modeshape.jcr.api.observation.Event.Sequencing.OUTPUT_PATH;
+import static org.modeshape.jcr.api.observation.Event.Sequencing.SELECTED_PATH;
+import static org.modeshape.jcr.api.observation.Event.Sequencing.SEQUENCED_NODE_ID;
+import static org.modeshape.jcr.api.observation.Event.Sequencing.SEQUENCED_NODE_PATH;
+import static org.modeshape.jcr.api.observation.Event.Sequencing.SEQUENCER_NAME;
+import static org.modeshape.jcr.api.observation.Event.Sequencing.USER_ID;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import javax.jcr.Node;
+import javax.jcr.RepositoryException;
+import javax.jcr.Workspace;
+import javax.jcr.observation.EventIterator;
+import javax.jcr.observation.EventListener;
+import javax.jcr.observation.EventListenerIterator;
+import javax.jcr.observation.ObservationManager;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.modeshape.common.logging.Logger;
+import org.modeshape.jcr.Environment;
+import org.modeshape.jcr.JcrI18n;
+import org.modeshape.jcr.JcrRepository;
+import org.modeshape.jcr.JcrSession;
+import org.modeshape.jcr.LocalEnvironment;
+import org.modeshape.jcr.ModeShapeEngine;
+import org.modeshape.jcr.ModeShapeEngine.State;
+import org.modeshape.jcr.RepositoryConfiguration;
+import org.modeshape.jcr.api.JcrConstants;
+import org.modeshape.jcr.api.JcrTools;
+import org.modeshape.jcr.api.nodetype.NodeTypeManager;
+import org.modeshape.jcr.api.observation.Event;
+
+/**
+ * Class which serves as base for various sequencer unit tests. In addition to this, it uses the sequencing events fired by
+ * ModeShape's {@link javax.jcr.observation.ObservationManager} to perform various assertions and therefore, acts as a test for
+ * those as well.
+ */
+public abstract class AbstractSequencerTest {
+
+    protected static ModeShapeEngine _engine;
+    protected static final int DEFAULT_WAIT_TIME_SECONDS = 15;
+    protected static final String REPO_NAME = "teiid-modeshape-sequencer-test-repository";
+
+    protected static final boolean START_REPO_AUTOMATICALLY = true;
+
+    @BeforeClass
+    public static void createEngine() {
+        _engine = new ModeShapeEngine();
+        _engine.start();
+    }
+
+    protected RepositoryConfiguration config;
+    protected Environment environment;
+    private final Logger logger = Logger.getLogger( getClass() );
+    private ObservationManager observationManager;
+    protected JcrRepository repository;
+    protected Node rootNode;
+    protected JcrSession session;
+    protected JcrTools tools;
+
+    /**
+     * A [node path, latch] map which is used to block tests waiting for sequenced output, until either the node has been
+     * sequenced or a timeout occurs
+     */
+    private final ConcurrentHashMap< String, CountDownLatch > nodeSequencedLatches = new ConcurrentHashMap< String, CountDownLatch >();
+
+    /**
+     * A [node path, node instance] map which is populated by the listener, once each sequencing event is received
+     */
+    private final Map< String, Node > sequencedNodes = new HashMap< String, Node >();
+
+    /**
+     * A [sequenced node path, event] map which will hold all the received sequencing events, both in failure and non-failure
+     * cases, using the path of the sequenced node as key.
+     */
+    private final ConcurrentHashMap< String, Event > sequencingEvents = new ConcurrentHashMap< String, Event >();
+
+    /**
+     * A [node path, latch] map which is used to block tests waiting for a sequencing failure, until either the failure has
+     * occurred or a timeout occurs
+     */
+    private final ConcurrentHashMap< String, CountDownLatch > sequencingFailureLatches = new ConcurrentHashMap< String, CountDownLatch >();
+
+    protected void addSequencingListeners( final JcrSession session ) throws RepositoryException {
+        this.observationManager.addEventListener( new SequencingListener(), NODE_SEQUENCED, null, true, null, null, false );
+        this.observationManager.addEventListener( new SequencingFailureListener(),
+                                                  NODE_SEQUENCING_FAILURE,
+                                                  null,
+                                                  true,
+                                                  null,
+                                                  null,
+                                                  false );
+    }
+
+    @After
+    public void afterEach() throws Exception {
+        for ( final EventListenerIterator it = this.observationManager.getRegisteredEventListeners(); it.hasNext(); ) {
+            this.observationManager.removeEventListener( it.nextEventListener() );
+        }
+
+        stopRepository();
+        cleanupData();
+    }
+
+    @Before
+    public void beforeEach() throws Exception {
+        if ( START_REPO_AUTOMATICALLY ) {
+            startRepository();
+        }
+
+        this.tools = new JcrTools();
+        this.rootNode = this.session.getRootNode();
+        addSequencingListeners( this.session );
+    }
+
+    private void cleanupData() {
+        this.sequencedNodes.clear();
+        this.sequencingEvents.clear();
+        this.nodeSequencedLatches.clear();
+        this.sequencingFailureLatches.clear();
+    }
+
+    /**
+     * Creates a nt:file node, under the root node, at the given path and with the jcr:data property pointing at the filepath.
+     *
+     * @param nodeRelativePath the path under the root node, where the nt:file will be created.
+     * @param filePath a path relative to {@link Class#getResourceAsStream(String)} where a file is expected at runtime
+     * @return the new node
+     * @throws RepositoryException if anything fails
+     */
+    protected Node createNodeWithContentFromFile( final String nodeRelativePath,
+                                                  final String filePath ) throws RepositoryException {
+        Node parent = this.rootNode;
+
+        for ( final String pathSegment : nodeRelativePath.split( "/" ) ) {
+            parent = parent.addNode( pathSegment );
+        }
+
+        final Node content = parent.addNode( JcrConstants.JCR_CONTENT );
+        content.setProperty( JcrConstants.JCR_DATA,
+                             ( ( javax.jcr.Session )this.session ).getValueFactory().createBinary( resourceStream( filePath ) ) );
+
+        this.session.save();
+        return parent;
+    }
+
+    private RepositoryConfiguration createRepositoryConfiguration( final String repositoryName ) throws Exception {
+        return RepositoryConfiguration.read( getRepositoryConfigStream(), repositoryName ).with( this.environment );
+    }
+
+    private void createWaitingLatchIfNecessary( final String expectedPath,
+                                                final ConcurrentHashMap< String, CountDownLatch > latchesMap ) {
+        latchesMap.putIfAbsent( expectedPath, new CountDownLatch( 1 ) );
+    }
+
+    /**
+     * Retrieves a sequenced node using 5 seconds as maximum wait time.
+     *
+     * @param parentNode an existing {@link Node}
+     * @param relativePath the path under the parent node at which the sequenced node is expected to appear (note that this must
+     *        be the path to the "new" node, always.
+     * @return either the sequenced node or null, if something has failed.
+     * @throws Exception if anything unexpected happens
+     * @see AbstractSequencerTest#getOutputNode(javax.jcr.Node, String, int)
+     */
+    protected Node getOutputNode( final Node parentNode,
+                                  final String relativePath ) throws Exception {
+        return this.getOutputNode( parentNode, relativePath, DEFAULT_WAIT_TIME_SECONDS );
+    }
+
+    /**
+     * Attempts to retrieve a node (which is expected to have been sequenced) under an existing parent node at a relative path.
+     * The sequenced node "appears" when the {@link SequencingListener} is notified of the sequencing process. The thread which
+     * calls this method either returns immediately if the node has already been sequenced, or waits a number of seconds for it to
+     * become available.
+     *
+     * @param parentNode an existing {@link Node}
+     * @param relativePath the path under the parent node at which the sequenced node is expected to appear (note that this must
+     *        be the path to the "new" node, always.
+     * @param waitTimeSeconds the max number of seconds to wait.
+     * @return either the sequenced node or null, if something has failed.
+     * @throws Exception if anything unexpected happens
+     * @throws java.lang.AssertionError if the specified period of time has elapsed, but not enough sequencing events were
+     *         received
+     */
+    protected Node getOutputNode( final Node parentNode,
+                                  final String relativePath,
+                                  final int waitTimeSeconds ) throws Exception {
+        final String parentNodePath = parentNode.getPath();
+        final String expectedPath = parentNodePath.endsWith( "/" ) ? parentNodePath + relativePath : parentNodePath + "/"
+                                                                                                     + relativePath;
+
+        return getOutputNode( expectedPath, waitTimeSeconds );
+    }
+
+    /**
+     * Retrieves a new node under the given path, as a result of sequecing, or returns null if the given timeout occurs.
+     *
+     * @param expectedPath
+     * @param waitTimeSeconds
+     * @return the output node
+     * @throws InterruptedException
+     */
+    protected Node getOutputNode( final String expectedPath,
+                                  final int waitTimeSeconds ) throws InterruptedException {
+        if ( !this.sequencedNodes.containsKey( expectedPath ) ) {
+            createWaitingLatchIfNecessary( expectedPath, this.nodeSequencedLatches );
+            this.logger.debug( "Waiting for sequenced node at: " + expectedPath );
+
+            final CountDownLatch countDownLatch = this.nodeSequencedLatches.get( expectedPath );
+            countDownLatch.await( waitTimeSeconds, TimeUnit.SECONDS );
+        }
+
+        this.nodeSequencedLatches.remove( expectedPath );
+        return this.sequencedNodes.remove( expectedPath );
+    }
+
+    /**
+     * Returns an input stream to a JSON file which will be used to configure the repository. By default, this is
+     * config/repo-config.json
+     *
+     * @return an {@code InputStream} instance
+     */
+    protected InputStream getRepositoryConfigStream() {
+        return resourceStream( "config/repo-config.json" );
+    }
+
+    protected void killRepository( final JcrRepository repository ) {
+        try {
+            if ( repository.getState() != State.RUNNING ) {
+                return;
+            }
+
+            _engine.undeploy( REPO_NAME );
+        } catch ( final Throwable t ) {
+            this.logger.error( JcrI18n.errorKillingRepository, repository.getName(), t.getMessage() );
+        }
+    }
+
+    /**
+     * Register the node types in the CND file at the given location on the classpath.
+     *
+     * @param resourceName the name of the CND file on the classpath
+     * @throws RepositoryException if there is a problem registering the node types
+     * @throws IOException if the CND file could not be read
+     */
+    protected void registerNodeTypes( final String resourceName ) throws RepositoryException, IOException {
+        final InputStream stream = resourceStream( resourceName );
+        assertThat( stream, is( notNullValue() ) );
+
+        final Workspace workspace = this.session.getWorkspace();
+        final NodeTypeManager ntMgr = ( NodeTypeManager )workspace.getNodeTypeManager();
+        ntMgr.registerNodeTypes( stream, true );
+    }
+
+    /**
+     * Utility method to get the resource on the classpath given by the supplied name
+     *
+     * @param name the name (or path) of the classpath resource
+     * @return the input stream to the content; may be null if the resource does not exist
+     */
+    protected InputStream resourceStream( final String name ) {
+        return getClass().getClassLoader().getResourceAsStream( name );
+    }
+
+    protected void smokeCheckSequencingEvent( final Event event,
+                                              final int expectedEventType,
+                                              final String... expectedEventInfoKeys ) throws RepositoryException {
+        assertEquals( event.getType(), expectedEventType );
+
+        final Map< ?, ? > info = event.getInfo();
+        assertNotNull( info );
+
+        for ( final String extraInfoKey : expectedEventInfoKeys ) {
+            assertNotNull( info.get( extraInfoKey ) );
+        }
+    }
+
+    protected void startRepository() throws Exception {
+        this.environment = new LocalEnvironment();
+        this.config = createRepositoryConfiguration( REPO_NAME );
+        this.repository = _engine.deploy( this.config );
+        this.session = this.repository.login();
+        this.observationManager = ( ( Workspace )this.session.getWorkspace() ).getObservationManager();
+    }
+
+    protected void stopRepository() throws Exception {
+        try {
+            try {
+                if ( ( this.session != null ) && this.session.isLive() ) {
+                    this.session.logout();
+                }
+            } finally {
+                killRepository( this.repository );
+            }
+        } finally {
+            this.repository = null;
+            this.config = null;
+            this.environment.shutdown();
+            this.environment = null;
+        }
+    }
+
+    protected final class SequencingFailureListener implements EventListener {
+        @SuppressWarnings( "synthetic-access" )
+        @Override
+        public void onEvent( final EventIterator events ) {
+            while ( events.hasNext() ) {
+                try {
+                    final Event event = ( Event )events.nextEvent();
+                    smokeCheckSequencingEvent( event,
+                                               NODE_SEQUENCING_FAILURE,
+                                               SEQUENCED_NODE_ID,
+                                               SEQUENCED_NODE_PATH,
+                                               Event.Sequencing.SEQUENCING_FAILURE_CAUSE,
+                                               OUTPUT_PATH,
+                                               SELECTED_PATH,
+                                               SEQUENCER_NAME,
+                                               USER_ID );
+                    final String nodePath = event.getPath();
+
+                    AbstractSequencerTest.this.sequencingEvents.putIfAbsent( nodePath, event );
+                    createWaitingLatchIfNecessary( nodePath, AbstractSequencerTest.this.sequencingFailureLatches );
+                    AbstractSequencerTest.this.sequencingFailureLatches.get( nodePath ).countDown();
+                } catch ( final Exception e ) {
+                    throw new RuntimeException( e );
+                }
+            }
+        }
+    }
+
+    protected final class SequencingListener implements EventListener {
+        @SuppressWarnings( "synthetic-access" )
+        @Override
+        public void onEvent( final EventIterator events ) {
+            while ( events.hasNext() ) {
+                try {
+                    final Event event = ( Event )events.nextEvent();
+                    smokeCheckSequencingEvent( event,
+                                               NODE_SEQUENCED,
+                                               SEQUENCED_NODE_ID,
+                                               SEQUENCED_NODE_PATH,
+                                               OUTPUT_PATH,
+                                               SELECTED_PATH,
+                                               SEQUENCER_NAME,
+                                               USER_ID );
+                    AbstractSequencerTest.this.sequencingEvents.putIfAbsent( ( String )event.getInfo().get( SEQUENCED_NODE_PATH ),
+                                                                             event );
+
+                    final String nodePath = event.getPath();
+                    AbstractSequencerTest.this.logger.debug( "New sequenced node at: " + nodePath );
+                    AbstractSequencerTest.this.sequencedNodes.put( nodePath,
+                                                                   AbstractSequencerTest.this.session.getNode( nodePath ) );
+
+                    // signal the node is available
+                    createWaitingLatchIfNecessary( nodePath, AbstractSequencerTest.this.nodeSequencedLatches );
+                    AbstractSequencerTest.this.nodeSequencedLatches.get( nodePath ).countDown();
+                } catch ( final Exception e ) {
+                    throw new RuntimeException( e );
+                }
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
- Copied over code from 3 different ModeShape sequencer test classes and created one sequencer test class.
- Copied over an I18n test class.
- Changed the ModeShape version to 3.8.4.GA.
- Changed parent version to 6.0.0.Final.
- Changed to use the Infinispan version property.