### PR TITLE
Issue 12: Module Names of Sequencers Are Incorrect

### DIFF
--- a/build/kits/jboss/org/teiid/modeshape/sequencer/ddl/main/module.xml
+++ b/build/kits/jboss/org/teiid/modeshape/sequencer/ddl/main/module.xml
@@ -20,7 +20,7 @@
  ~ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
  ~ 02110-1301 USA.
 -->
-<module xmlns="urn:jboss:module:1.3" name="org.teiid.modeshape.sequencer.ddl">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.teiid.modeshape.sequencer.ddl">
     <resources>
         <resource-root path="teiid-modeshape-sequencer-ddl-${project.version}.jar" />
     </resources>

--- a/build/kits/jboss/org/teiid/modeshape/sequencer/vdb/main/module.xml
+++ b/build/kits/jboss/org/teiid/modeshape/sequencer/vdb/main/module.xml
@@ -20,7 +20,7 @@
  ~ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
  ~ 02110-1301 USA.
 -->
-<module xmlns="urn:jboss:module:1.2" name="org.teiid.modeshape.sequencer.vdb">
+<module xmlns="urn:jboss:module:1.2" name="org.jboss.teiid.modeshape.sequencer.vdb">
     <resources>
         <resource-root path="teiid-modeshape-sequencer-vdb-${project.version}.jar" />
     </resources>


### PR DESCRIPTION
Updated both sequencer module.xml files to add "jboss" to match the file path segment.