### PR TITLE
18 Change Master Branch To Use ModeShape 5.0.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,13 +29,12 @@
     <!-- ================================================================== -->
     <properties>
         <hamcrest.version>1.3</hamcrest.version>
-        <infinispan.version>7.2.4.Final</infinispan.version>
         <jboss.kit.modules.location>modules/system/layers/dv/org/jboss/teiid/modeshape/sequencer</jboss.kit.modules.location>
         <jboss.scripts.location>cli-scripts</jboss.scripts.location>
         <jboss.vdb.location>dataVirtualization/vdb</jboss.vdb.location>
-        <junit.version>4.11</junit.version>
-        <log4j.version>1.2.16</log4j.version>
-        <modeshape.version>4.6.0.Final</modeshape.version>
+        <junit.version>4.12</junit.version>
+        <log4j.version>1.2.17</log4j.version>
+        <modeshape.version>5.0.0.Final</modeshape.version>
         <slf4j.api.version>1.7.2</slf4j.api.version>
         <slf4j.log4j.version>1.7.2</slf4j.log4j.version>
     </properties>

--- a/sequencers/teiid-modeshape-sequencer-ddl/src/test/resources/log4j.properties
+++ b/sequencers/teiid-modeshape-sequencer-ddl/src/test/resources/log4j.properties
@@ -10,10 +10,6 @@ log4j.rootLogger=INFO, stdout
 # Set up the default logging to be INFO level, then override specific units
 log4j.logger.org.teiid.modeshape=INFO
 
-#Infinispan 5.2 prints a lot of info messages around jmx
-log4j.logger.org.infinispan.jmx=ERROR
-log4j.logger.org.infinispan.transaction.lookup=WARN
-
 # Turn off the serialization protocol used in Hibernate Search (for clustering)
 # The log line is "Serialization protocol version 1.0 ..." or similar every time the repository is started,
 # and the following line disables it.

--- a/sequencers/teiid-modeshape-sequencer-vdb/src/test/resources/log4j.properties
+++ b/sequencers/teiid-modeshape-sequencer-vdb/src/test/resources/log4j.properties
@@ -24,7 +24,3 @@ log4j.logger.org.teiid.modeshape=INFO
 # The log line is "Serialization protocol version 1.0 ..." or similar every time the repository is started,
 # and the following line disables it.
 log4j.logger.org.hibernate.search.indexes.serialization.avro.impl.AvroSerializationProvider=OFF
-
-#Infinispan 5.2 prints a lot of info messages around jmx
-log4j.logger.org.infinispan.jmx=ERROR
-log4j.logger.org.infinispan.transaction.lookup=WARN


### PR DESCRIPTION
Change the pom to use latest ModeShape release. Also removed unused pom properties and references to Infinispan in the log4j.properties files.