### PR TITLE
More work supporting the new data service sequencer in support of the Komodo project

### DIFF
--- a/sequencers/teiid-modeshape-sequencer-dataservice/src/main/java/org/teiid/modeshape/sequencer/dataservice/Connection.java
+++ b/sequencers/teiid-modeshape-sequencer-dataservice/src/main/java/org/teiid/modeshape/sequencer/dataservice/Connection.java
@@ -23,7 +23,6 @@ package org.teiid.modeshape.sequencer.dataservice;
 
 import java.util.Objects;
 import java.util.Properties;
-import org.modeshape.common.logging.Logger;
 import org.modeshape.common.util.StringUtil;
 
 /**
@@ -31,10 +30,7 @@ import org.modeshape.common.util.StringUtil;
  */
 public class Connection {
 
-    static final Logger LOGGER = Logger.getLogger( Connection.class );
-
     private String className;
-
     private String description;
     private String driverName;
     private String jndiName;

--- a/sequencers/teiid-modeshape-sequencer-dataservice/src/main/java/org/teiid/modeshape/sequencer/dataservice/ConnectionReader.java
+++ b/sequencers/teiid-modeshape-sequencer-dataservice/src/main/java/org/teiid/modeshape/sequencer/dataservice/ConnectionReader.java
@@ -26,6 +26,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
@@ -52,11 +53,11 @@ import org.xml.sax.helpers.DefaultHandler;
 public final class ConnectionReader extends DefaultHandler {
 
     /**
-     * The valid connection file extensions. Value is {@value}.
+     * The valid connection file extension. Value is {@value}.
      */
-    public static final String[] FILE_EXTENSIONS = { "-connection.xml" }; //$NON-NLS-1$
+    public static final String FILE_EXTENSION = "-connection.xml"; //$NON-NLS-1$
 
-    private static final String DATA_SOURCE_SCHEMA_FILE = "org/teiid/modeshape/sequencer/dataService/connection.xsd"; //$NON-NLS-1$
+    private static final String DATA_SOURCE_SCHEMA_FILE = "connection.xsd"; //$NON-NLS-1$
     private static final Logger LOGGER = Logger.getLogger( ConnectionReader.class );
 
     private final StringBuilder className;
@@ -248,11 +249,11 @@ public final class ConnectionReader extends DefaultHandler {
     }
 
     private void initParser() throws Exception {
-        final InputStream schemaStream = getClass().getClassLoader().getResourceAsStream( DATA_SOURCE_SCHEMA_FILE );
-
+        final URL schemaUrl = getClass().getResource( DATA_SOURCE_SCHEMA_FILE );
+        
         try {
             this.schemaFile = File.createTempFile( "dataSourceSchemaFile", ".xsd" ); //$NON-NLS-1$ //$NON-NLS-2$
-            Files.copy( schemaStream, this.schemaFile.toPath(), StandardCopyOption.REPLACE_EXISTING );
+            Files.copy( schemaUrl.openStream(), this.schemaFile.toPath(), StandardCopyOption.REPLACE_EXISTING );
             this.schemaFile.deleteOnExit();
             LOGGER.debug( "connection schema file loaded" ); //$NON-NLS-1$
         } catch ( final IOException e ) {

--- a/sequencers/teiid-modeshape-sequencer-dataservice/src/main/java/org/teiid/modeshape/sequencer/dataservice/ConnectionSequencer.java
+++ b/sequencers/teiid-modeshape-sequencer-dataservice/src/main/java/org/teiid/modeshape/sequencer/dataservice/ConnectionSequencer.java
@@ -58,13 +58,7 @@ public class ConnectionSequencer extends Sequencer {
         CheckArg.isNotNull( binaryValue, "binary" );
 
         try ( final InputStream connectionStream = binaryValue.getStream() ) {
-            final Connection connection = readConnection( connectionStream, outputNode, context );
-
-            if ( connection == null ) {
-                throw new Exception( TeiidI18n.noDatasourceFound.text( inputProperty.getPath() ) );
-            }
-        } catch ( final Exception e ) {
-            throw new RuntimeException( TeiidI18n.errorReadingDatasourceFile.text( inputProperty.getPath(), e.getMessage() ), e );
+            sequenceConnection( connectionStream, outputNode );
         }
 
         return true;
@@ -131,20 +125,20 @@ public class ConnectionSequencer extends Sequencer {
     /**
      * @param connectionStream the stream being processed (cannot be <code>null</code>)
      * @param connectionOutputNode the repository output node (cannot be <code>null</code>)
-     * @return <code>true</code> if the connection was sequenced successfully
-     * @throws Exception
+     * @return the connection that was sequenced successfully (never <code>null</code>)
+     * @throws Exception if an error occurs
      */
-    public boolean sequenceConnection( final InputStream connectionStream,
-                                       final Node connectionOutputNode ) throws Exception {
+    public Connection sequenceConnection( final InputStream connectionStream,
+                                          final Node connectionOutputNode ) throws Exception {
         final Connection ds = readConnection( Objects.requireNonNull( connectionStream, "connectionStream" ),
                                               Objects.requireNonNull( connectionOutputNode, "connectionOutputNode" ),
                                               null );
 
         if ( ds == null ) {
-            throw new RuntimeException( TeiidI18n.errorReadingDatasourceFile.text( connectionOutputNode.getPath() ) );
+            throw new Exception( TeiidI18n.errorReadingDatasourceFile.text( connectionOutputNode.getPath() ) );
         }
 
-        return true;
+        return ds;
     }
 
 }

--- a/sequencers/teiid-modeshape-sequencer-dataservice/src/main/java/org/teiid/modeshape/sequencer/dataservice/DataServiceManifest.java
+++ b/sequencers/teiid-modeshape-sequencer-dataservice/src/main/java/org/teiid/modeshape/sequencer/dataservice/DataServiceManifest.java
@@ -37,9 +37,14 @@ import org.modeshape.common.util.StringUtil;
 public class DataServiceManifest implements VdbEntryContainer {
 
     /**
+     * The date pattern used for the last modified property.
+     */
+    public static final String DATE_PATTERN = "yyyy-MM-dd'T'HH:mm:ss";
+
+    /**
      * The date formatter for the last modified property.
      */
-    public static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern( "yyyy-MM-dd'T'HH:mm:ss" );
+    public static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern( DATE_PATTERN );
 
     /**
      * @param lastModifiedDate the string representation of the date being parsed (cannot be <code>null</code>)
@@ -116,8 +121,8 @@ public class DataServiceManifest implements VdbEntryContainer {
     /**
      * @return the entry paths of the connection files (never <code>null</code> but can be empty)
      */
-    public String[] getDataSourcePaths() {
-        final DataServiceEntry[] entries = getDataSources();
+    public String[] getConnectionPaths() {
+        final DataServiceEntry[] entries = getConnections();
 
         if ( entries.length == 0 ) {
             return DataServiceEntry.NO_PATHS;
@@ -129,7 +134,7 @@ public class DataServiceManifest implements VdbEntryContainer {
     /**
      * @return the connection entries (never <code>null</code> but can be empty)
      */
-    public ConnectionEntry[] getDataSources() {
+    public ConnectionEntry[] getConnections() {
         if ( this.dataSources.isEmpty() ) {
             return ConnectionEntry.NO_DATA_SOURCES;
         }
@@ -169,7 +174,7 @@ public class DataServiceManifest implements VdbEntryContainer {
     }
 
     /**
-     * @return the last time the manifest was modified (can be <code>null</code> or empty)
+     * @return the last time the manifest was modified (can be <code>null</code>)
      */
     public LocalDateTime getLastModified() {
         return this.lastModified;

--- a/sequencers/teiid-modeshape-sequencer-dataservice/src/main/java/org/teiid/modeshape/sequencer/dataservice/DataServiceManifestReader.java
+++ b/sequencers/teiid-modeshape-sequencer-dataservice/src/main/java/org/teiid/modeshape/sequencer/dataservice/DataServiceManifestReader.java
@@ -26,6 +26,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.time.LocalDateTime;
@@ -61,7 +62,7 @@ public final class DataServiceManifestReader extends DefaultHandler {
 
     }
 
-    private static final String DATA_SERVICE_SCHEMA_FILE = "org/teiid/modeshape/sequencer/dataService/dataService.xsd"; //$NON-NLS-1$
+    private static final String DATA_SERVICE_SCHEMA_FILE = "dataService.xsd"; //$NON-NLS-1$
     private static final Logger LOGGER = Logger.getLogger( DataServiceManifestReader.class );
 
     private ConnectionEntry dataSource;
@@ -293,11 +294,11 @@ public final class DataServiceManifestReader extends DefaultHandler {
     }
 
     private void initParser() throws Exception {
-        final InputStream schemaStream = getClass().getClassLoader().getResourceAsStream( DATA_SERVICE_SCHEMA_FILE );
+        final URL schemaUrl = getClass().getResource( DATA_SERVICE_SCHEMA_FILE );
 
         try {
             this.schemaFile = File.createTempFile( "dataServiceSchemaFile", ".xsd" ); //$NON-NLS-1$ //$NON-NLS-2$
-            Files.copy( schemaStream, this.schemaFile.toPath(), StandardCopyOption.REPLACE_EXISTING );
+            Files.copy( schemaUrl.openStream(), this.schemaFile.toPath(), StandardCopyOption.REPLACE_EXISTING );
             this.schemaFile.deleteOnExit();
             LOGGER.debug( "Data Service schema file loaded" ); //$NON-NLS-1$
         } catch ( final IOException e ) {

--- a/sequencers/teiid-modeshape-sequencer-dataservice/src/main/java/org/teiid/modeshape/sequencer/dataservice/TeiidI18n.java
+++ b/sequencers/teiid-modeshape-sequencer-dataservice/src/main/java/org/teiid/modeshape/sequencer/dataservice/TeiidI18n.java
@@ -32,7 +32,6 @@ public final class TeiidI18n {
     public static I18n errorReadingDatasourceFile;
     public static I18n fileSequencingError;
     public static I18n missingDataServiceManifestFile;
-    public static I18n noDatasourceFound;
     public static I18n unexpectedDeployPolicy;
     public static I18n vdbSequencingError;
 

--- a/sequencers/teiid-modeshape-sequencer-dataservice/src/main/java/org/teiid/modeshape/sequencer/dataservice/lexicon/DataVirtLexicon.java
+++ b/sequencers/teiid-modeshape-sequencer-dataservice/src/main/java/org/teiid/modeshape/sequencer/dataservice/lexicon/DataVirtLexicon.java
@@ -209,6 +209,11 @@ public interface DataVirtLexicon {
         String PATH = PREFIX + ":entryPath";
 
         /**
+         * The name of the property whose value is the publish policy of the entry. Value is {@value}.
+         */
+        String PUBLISH_POLICY = PREFIX + ":publishPolicy";
+
+        /**
          * The name of the property whose value is a reference to a resource or a node that can export a resource. Value is
          * {@value}.
          */
@@ -262,6 +267,11 @@ public interface DataVirtLexicon {
          * The name of the property whose value is the archive path of the entry. Value is {@value}.
          */
         String PATH = DataServiceEntry.PATH;
+
+        /**
+         * The name of the property whose value is the publish policy of the entry. Value is {@value}.
+         */
+        String PUBLISH_POLICY = DataServiceEntry.PUBLISH_POLICY;
 
         /**
          * The name of the property whose value is the reference of the connection resource. Value is {@value}.
@@ -323,84 +333,6 @@ public interface DataVirtLexicon {
     }
 
     /**
-     * JCR identifiers relating to a data service entry for a driver file.
-     */
-    interface DriverEntry {
-
-        /**
-         * The name of the driver entry node type. Value is {@value}.
-         */
-        String NODE_TYPE = PREFIX + ":driverEntry";
-
-        /**
-         * The name of the property whose value is the archive path of the entry. Value is {@value}.
-         */
-        String PATH = DataServiceEntry.PATH;
-
-        /**
-         * The name of the property whose value is the reference of the driver resource. Value is {@value}.
-         */
-        String DRIVER_REF = DataServiceEntry.SOURCE_RESOURCE;
-
-    }
-
-    /**
-     * JCR identifiers relating to a driver file.
-     */
-    interface DriverFile {
-
-        /**
-         * The name of the driver file node type. Value is {@value}.
-         */
-        String NODE_TYPE = PREFIX + ":driverFile";
-
-    }
-
-    /**
-     * JCR identifiers relating to metadata files.
-     */
-    interface MetadaFile {
-
-        /**
-         * The name of the DDL metadata file node type. Value is {@value}.
-         */
-        String DDL_FILE_NODE_TYPE = PREFIX + ":ddlFile";
-
-        /**
-         * The name of the abstract metadata file node type. Value is {@value}.
-         */
-        String NODE_TYPE = PREFIX + ":metadataFile";
-
-    }
-
-    /**
-     * JCR identifiers relating to a data service entry for a metadata file.
-     */
-    interface MetadataEntry {
-
-        /**
-         * The name of the DDL file entry node type. Value is {@value}.
-         */
-        String DDL_FILE_NODE_TYPE = PREFIX + ":ddlEntry";
-
-        /**
-         * The name of the abstract metadata entry node type. Value is {@value}.
-         */
-        String NODE_TYPE = PREFIX + ":metadataEntry";
-
-        /**
-         * The name of the property whose value is the path of the metadata entry. Value is {@value}.
-         */
-        String PATH = DataServiceEntry.PATH;
-
-        /**
-         * The name of the property whose value is the reference of the metadata file. Value is {@value}.
-         */
-        String METADATA_REF = DataServiceEntry.SOURCE_RESOURCE;
-
-    }
-
-    /**
      * The URI and prefix constants of the DV namespace.
      */
     interface Namespace {
@@ -428,14 +360,29 @@ public interface DataVirtLexicon {
         String NODE_TYPE = PREFIX + ":resourceEntry";
 
         /**
+         * The name of the DDL file entry node type. Value is {@value}.
+         */
+        String DDL_ENTRY_NODE_TYPE = PREFIX + ":ddlEntry";
+
+        /**
+         * The name of the driver entry node type. Value is {@value}.
+         */
+        String DRIVER_ENTRY_NODE_TYPE = PREFIX + ":driverEntry";
+
+        /**
          * The name of the UDF file entry node type. Value is {@value}.
          */
-        String UDF_FILE_NODE_TYPE = PREFIX + ":udfEntry";
+        String UDF_ENTRY_NODE_TYPE = PREFIX + ":udfEntry";
 
         /**
          * The name of the property whose value is the resource path of the entry. Value is {@value}.
          */
         String PATH = DataServiceEntry.PATH;
+
+        /**
+         * The name of the property whose value is the publish policy of the entry. Value is {@value}.
+         */
+        String PUBLISH_POLICY = DataServiceEntry.PUBLISH_POLICY;
 
         /**
          * The name of the property whose value is the reference of the resource file. Value is {@value}.
@@ -453,6 +400,16 @@ public interface DataVirtLexicon {
          * The name of the generic resource file node type. Value is {@value}.
          */
         String NODE_TYPE = PREFIX + ":resourceFile";
+
+        /**
+         * The name of the DDL metadata file node type. Value is {@value}.
+         */
+        String DDL_FILE_NODE_TYPE = PREFIX + ":ddlFile";
+
+        /**
+         * The name of the driver file node type. Value is {@value}.
+         */
+        String DRIVER_FILE_NODE_TYPE = PREFIX + ":driverFile";
 
         /**
          * The name of the UDF file node type. Value is {@value}.
@@ -475,6 +432,11 @@ public interface DataVirtLexicon {
          * The name of the property whose value is the archive path of the entry. Value is {@value}.
          */
         String PATH = DataServiceEntry.PATH;
+
+        /**
+         * The name of the property whose value is the publish policy of the entry. Value is {@value}.
+         */
+        String PUBLISH_POLICY = DataServiceEntry.PUBLISH_POLICY;
 
         /**
          * The name of the property whose value is the reference of the driver resource. Value is {@value}.
@@ -507,6 +469,11 @@ public interface DataVirtLexicon {
          * The name of the property whose value is the archive path of the entry. Value is {@value}.
          */
         String PATH = DataServiceEntry.PATH;
+
+        /**
+         * The name of the property whose value is the publish policy of the entry. Value is {@value}.
+         */
+        String PUBLISH_POLICY = DataServiceEntry.PUBLISH_POLICY;
 
         /**
          * The name of the property whose value is the reference of the driver resource. Value is {@value}.

--- a/sequencers/teiid-modeshape-sequencer-dataservice/src/main/resources/org/teiid/modeshape/sequencer/dataservice/TeiidI18n.properties
+++ b/sequencers/teiid-modeshape-sequencer-dataservice/src/main/resources/org/teiid/modeshape/sequencer/dataservice/TeiidI18n.properties
@@ -23,7 +23,6 @@ errorReadingDataserviceFile = Error reading data service file "{0}": {1}
 errorReadingDatasourceFile = Error reading data source file "{0}": {1}
 fileSequencingError = Error sequencing file for data service at path "{0}"
 missingDataServiceManifestFile = The data service at path "{0}" does not have a manifest
-noDatasourceFound = Reading data source definition file "{0}" did not create a data source
 unexpectedDeployPolicy = Unexpected deploy policy of "{0}" for entry "{1}"
 vdbSequencingError = Error sequencing VDB for data service at path "{0}"
 

--- a/sequencers/teiid-modeshape-sequencer-dataservice/src/main/resources/org/teiid/modeshape/sequencer/dataservice/dv.cnd
+++ b/sequencers/teiid-modeshape-sequencer-dataservice/src/main/resources/org/teiid/modeshape/sequencer/dataservice/dv.cnd
@@ -32,20 +32,23 @@
 //------------------------------------------------------------------------------
 
 /*
- * A driver file.
- */
-[dv:driverFile] > nt:file, mix:referenceable
-
-/*
- * A metadata file (DDL).
- */
-[dv:metadataFile] > nt:file, mix:referenceable abstract
-[dv:ddlFile] > dv:metadataFile
-
-/*
- * A resource file (UDF).
+ * A resource file (like a UDF, driver, and DDL).
  */
 [dv:resourceFile] > nt:file, mix:referenceable
+
+/*
+ * A driver file.
+ */
+[dv:driverFile] > dv:resourceFile
+
+/*
+ * A DDL file.
+ */
+[dv:ddlFile] > dv:resourceFile
+
+/*
+ * A UDF file.
+ */
 [dv:udfFile] > dv:resourceFile
    
 /*
@@ -62,6 +65,7 @@
  */
 [dv:dataServiceEntry] > nt:unstructured abstract
   - dv:path (string)
+  - dv:publishPolicy (string) = 'IF_MISSING' autocreated < 'ALWAYS', 'IF_MISSING', 'NEVER' 
   - dv:sourceResource (reference) // reference to resource being put in the archive
 
 /*

--- a/sequencers/teiid-modeshape-sequencer-dataservice/src/test/java/org/teiid/modeshape/sequencer/dataservice/DataServiceManifestTest.java
+++ b/sequencers/teiid-modeshape-sequencer-dataservice/src/test/java/org/teiid/modeshape/sequencer/dataservice/DataServiceManifestTest.java
@@ -26,6 +26,7 @@ import static org.hamcrest.core.IsNull.notNullValue;
 import static org.hamcrest.core.IsNull.nullValue;
 import static org.junit.Assert.assertThat;
 import java.io.InputStream;
+import java.net.URL;
 import java.time.LocalDateTime;
 import org.junit.Test;
 import org.xml.sax.SAXParseException;
@@ -58,8 +59,8 @@ public final class DataServiceManifestTest {
 
         assertThat( manifest.getProperties().size(), is( 0 ) );
 
-        assertThat( manifest.getDataSources().length, is( 1 ) );
-        assertThat( manifest.getDataSourcePaths().length, is( 1 ) );
+        assertThat( manifest.getConnections().length, is( 1 ) );
+        assertThat( manifest.getConnectionPaths().length, is( 1 ) );
         assertThat( manifest.getDrivers().length, is( 0 ) );
         assertThat( manifest.getDriverPaths().length, is( 0 ) );
         assertThat( manifest.getMetadata().length, is( 0 ) );
@@ -71,9 +72,9 @@ public final class DataServiceManifestTest {
         assertThat( manifest.getVdbs().length, is( 0 ) );
         assertThat( manifest.getVdbPaths().length, is( 0 ) );
 
-        final ConnectionEntry ds = manifest.getDataSources()[ 0 ];
+        final ConnectionEntry ds = manifest.getConnections()[ 0 ];
         assertThat( ds.getPath(), is( "products-connection.xml" ) );
-        assertThat( manifest.getDataSourcePaths()[ 0 ], is( ds.getPath() ) );
+        assertThat( manifest.getConnectionPaths()[ 0 ], is( ds.getPath() ) );
         assertThat( ds.getPublishPolicy(), is( DataServiceEntry.PublishPolicy.IF_MISSING ) );
         assertThat( ds.getJndiName(), is( "productsConnection" ) );
     }
@@ -90,8 +91,8 @@ public final class DataServiceManifestTest {
         assertThat( manifest.getProperties().size(), is( 1 ) );
         assertThat( manifest.getPropertyValue( "propA" ), is( "Value A" ) );
 
-        assertThat( manifest.getDataSources().length, is( 2 ) );
-        assertThat( manifest.getDataSourcePaths().length, is( 2 ) );
+        assertThat( manifest.getConnections().length, is( 2 ) );
+        assertThat( manifest.getConnectionPaths().length, is( 2 ) );
         assertThat( manifest.getDrivers().length, is( 2 ) );
         assertThat( manifest.getDriverPaths().length, is( 2 ) );
         assertThat( manifest.getMetadata().length, is( 2 ) );
@@ -116,8 +117,8 @@ public final class DataServiceManifestTest {
         assertThat( manifest.getProperties().size(), is( 1 ) );
         assertThat( manifest.getPropertyValue( "foo" ), is( "bar" ) );
 
-        assertThat( manifest.getDataSources().length, is( 0 ) );
-        assertThat( manifest.getDataSourcePaths().length, is( 0 ) );
+        assertThat( manifest.getConnections().length, is( 0 ) );
+        assertThat( manifest.getConnectionPaths().length, is( 0 ) );
         assertThat( manifest.getDrivers().length, is( 1 ) );
         assertThat( manifest.getDriverPaths().length, is( 1 ) );
         assertThat( manifest.getMetadata().length, is( 0 ) );
@@ -141,8 +142,8 @@ public final class DataServiceManifestTest {
 
         assertThat( manifest.getProperties().size(), is( 0 ) );
 
-        assertThat( manifest.getDataSources().length, is( 0 ) );
-        assertThat( manifest.getDataSourcePaths().length, is( 0 ) );
+        assertThat( manifest.getConnections().length, is( 0 ) );
+        assertThat( manifest.getConnectionPaths().length, is( 0 ) );
         assertThat( manifest.getDrivers().length, is( 0 ) );
         assertThat( manifest.getDriverPaths().length, is( 0 ) );
         assertThat( manifest.getMetadata().length, is( 1 ) );
@@ -166,8 +167,8 @@ public final class DataServiceManifestTest {
 
         assertThat( manifest.getProperties().size(), is( 0 ) );
 
-        assertThat( manifest.getDataSources().length, is( 0 ) );
-        assertThat( manifest.getDataSourcePaths().length, is( 0 ) );
+        assertThat( manifest.getConnections().length, is( 0 ) );
+        assertThat( manifest.getConnectionPaths().length, is( 0 ) );
         assertThat( manifest.getDrivers().length, is( 0 ) );
         assertThat( manifest.getDriverPaths().length, is( 0 ) );
         assertThat( manifest.getMetadata().length, is( 0 ) );
@@ -194,8 +195,8 @@ public final class DataServiceManifestTest {
         assertThat( manifest.getPropertyValue( "propB" ), is( "Value B" ) );
         assertThat( manifest.getPropertyValue( "propC" ), is( "Value C" ) );
 
-        assertThat( manifest.getDataSources().length, is( 0 ) );
-        assertThat( manifest.getDataSourcePaths().length, is( 0 ) );
+        assertThat( manifest.getConnections().length, is( 0 ) );
+        assertThat( manifest.getConnectionPaths().length, is( 0 ) );
         assertThat( manifest.getDrivers().length, is( 0 ) );
         assertThat( manifest.getDriverPaths().length, is( 0 ) );
         assertThat( manifest.getMetadata().length, is( 0 ) );
@@ -219,8 +220,8 @@ public final class DataServiceManifestTest {
 
         assertThat( manifest.getProperties().size(), is( 0 ) );
 
-        assertThat( manifest.getDataSources().length, is( 0 ) );
-        assertThat( manifest.getDataSourcePaths().length, is( 0 ) );
+        assertThat( manifest.getConnections().length, is( 0 ) );
+        assertThat( manifest.getConnectionPaths().length, is( 0 ) );
         assertThat( manifest.getDrivers().length, is( 0 ) );
         assertThat( manifest.getDriverPaths().length, is( 0 ) );
         assertThat( manifest.getMetadata().length, is( 0 ) );
@@ -234,30 +235,33 @@ public final class DataServiceManifestTest {
     }
 
     private InputStream streamFor( final String resourcePath ) throws Exception {
-        final InputStream istream = getClass().getResourceAsStream( resourcePath );
+        final URL resourceUrl = getClass().getResource( resourcePath );
+        final InputStream istream = resourceUrl.openStream();
         assertThat( istream, is( notNullValue() ) );
         return istream;
     }
-    //
-    // @Test( expected = Exception.class )
-    // public void shouldNotAllowSettingServiceVdbMoreThanOnce() throws Exception {
-    // final DataServiceManifest manifest = new DataServiceManifest();
-    // manifest.setServiceVdb( new DataserviceServiceVdb( manifest ) );
-    // manifest.setServiceVdb( new DataserviceServiceVdb( manifest ) );
-    // }
-    //
-    // @Test
-    // public void shouldAddImportVdb() throws Exception {
-    // final DataServiceManifest manifest = new DataServiceManifest();
-    // manifest.addImportVdb( new DataserviceImportVdb( manifest ) );
-    // assertThat( manifest.getImportVdbs().size(), is( 1 ) );
-    // }
-    //
-    // @Test
-    // public void shouldHaveExpectedInitialState() throws Exception {
-    // final DataServiceManifest manifest = new DataServiceManifest();
-    // assertThat( manifest.getServiceVdb(), is( nullValue() ) );
-    // assertThat( manifest.getImportVdbs().isEmpty(), is( true ) );
-    // }
+
+    @Test
+    public void shouldHaveExpectedInitialState() throws Exception {
+        final DataServiceManifest manifest = new DataServiceManifest();
+        assertThat( manifest.getDescription(), is( nullValue() ) );
+        assertThat( manifest.getLastModified(), is( nullValue() ) );
+        assertThat( manifest.getModifiedBy(), is( nullValue() ) );
+        assertThat( manifest.getServiceVdb(), is( nullValue() ) );
+        assertThat( manifest.getServiceVdbPath(), is( nullValue() ) );
+        assertThat( manifest.getProperties().size(), is( 0 ) );
+        assertThat( manifest.getConnectionPaths().length, is( 0 ) );
+        assertThat( manifest.getConnections().length, is( 0 ) );
+        assertThat( manifest.getDriverPaths().length, is( 0 ) );
+        assertThat( manifest.getDrivers().length, is( 0 ) );
+        assertThat( manifest.getMetadataPaths().length, is( 0 ) );
+        assertThat( manifest.getMetadata().length, is( 0 ) );
+        assertThat( manifest.getResourcePaths().length, is( 0 ) );
+        assertThat( manifest.getResources().length, is( 0 ) );
+        assertThat( manifest.getUdfPaths().length, is( 0 ) );
+        assertThat( manifest.getUdfs().length, is( 0 ) );
+        assertThat( manifest.getVdbPaths().length, is( 0 ) );
+        assertThat( manifest.getVdbs().length, is( 0 ) );
+    }
 
 }

--- a/sequencers/teiid-modeshape-sequencer-dataservice/src/test/java/org/teiid/modeshape/sequencer/dataservice/DataServiceSequencerTest.java
+++ b/sequencers/teiid-modeshape-sequencer-dataservice/src/test/java/org/teiid/modeshape/sequencer/dataservice/DataServiceSequencerTest.java
@@ -42,7 +42,7 @@ public final class DataServiceSequencerTest extends AbstractSequencerTest {
 
     private void assertConnection( final Node dataServiceNode,
                                    final String dsEntryName,
-                                   final DataServiceEntry.PublishPolicy deployPolicy ) throws Exception {
+                                   final DataServiceEntry.PublishPolicy publishPolicy ) throws Exception {
         assertThat( dataServiceNode.hasNode( dsEntryName ), is( true ) );
 
         final Node dsEntryNode = dataServiceNode.getNode( dsEntryName );
@@ -50,50 +50,59 @@ public final class DataServiceSequencerTest extends AbstractSequencerTest {
         assertThat( dsEntryNode.hasProperty( DataVirtLexicon.ConnectionEntry.PATH ), is( true ) );
         assertThat( dsEntryNode.getProperty( DataVirtLexicon.ConnectionEntry.PATH ).getString(),
                     is( "connections/" + dsEntryName ) );
+        assertThat( dsEntryNode.hasProperty( DataVirtLexicon.ConnectionEntry.PUBLISH_POLICY ), is( true ) );
+        assertThat( dsEntryNode.getProperty( DataVirtLexicon.ConnectionEntry.PUBLISH_POLICY ).getString(),
+                    is( publishPolicy.name() ) );
 
         // check reference
         assertReferencedResource( dsEntryNode,
                                   DataVirtLexicon.ConnectionEntry.CONNECTION_REF,
                                   DataVirtLexicon.Connection.NODE_TYPE,
-                                  deployPolicy,
+                                  publishPolicy,
                                   false );
     }
 
     private void assertDdl( final Node dataServiceNode,
                             final String ddlEntryName,
-                            final DataServiceEntry.PublishPolicy deployPolicy ) throws Exception {
+                            final DataServiceEntry.PublishPolicy publishPolicy ) throws Exception {
         assertThat( dataServiceNode.hasNode( ddlEntryName ), is( true ) );
 
         final Node ddlEntryNode = dataServiceNode.getNode( ddlEntryName );
-        assertThat( ddlEntryNode.getPrimaryNodeType().getName(), is( DataVirtLexicon.MetadataEntry.DDL_FILE_NODE_TYPE ) );
-        assertThat( ddlEntryNode.hasProperty( DataVirtLexicon.MetadataEntry.PATH ), is( true ) );
-        assertThat( ddlEntryNode.getProperty( DataVirtLexicon.MetadataEntry.PATH ).getString(),
+        assertThat( ddlEntryNode.getPrimaryNodeType().getName(), is( DataVirtLexicon.ResourceEntry.DDL_ENTRY_NODE_TYPE ) );
+        assertThat( ddlEntryNode.hasProperty( DataVirtLexicon.ResourceEntry.PATH ), is( true ) );
+        assertThat( ddlEntryNode.getProperty( DataVirtLexicon.ResourceEntry.PATH ).getString(),
                     is( "metadata/" + ddlEntryName ) );
+        assertThat( ddlEntryNode.hasProperty( DataVirtLexicon.ConnectionEntry.PUBLISH_POLICY ), is( true ) );
+        assertThat( ddlEntryNode.getProperty( DataVirtLexicon.ConnectionEntry.PUBLISH_POLICY ).getString(),
+                    is( publishPolicy.name() ) );
 
         // check reference
         assertReferencedResource( ddlEntryNode,
-                                  DataVirtLexicon.MetadataEntry.METADATA_REF,
-                                  DataVirtLexicon.MetadaFile.DDL_FILE_NODE_TYPE,
-                                  deployPolicy,
+                                  DataVirtLexicon.ResourceEntry.RESOURCE_REF,
+                                  DataVirtLexicon.ResourceFile.DDL_FILE_NODE_TYPE,
+                                  publishPolicy,
                                   true );
     }
 
     private void assertDriver( final Node dataServiceNode,
                                final String driverEntryName,
-                               final DataServiceEntry.PublishPolicy deployPolicy ) throws Exception {
+                               final DataServiceEntry.PublishPolicy publishPolicy ) throws Exception {
         assertThat( dataServiceNode.hasNode( driverEntryName ), is( true ) );
 
         final Node driverEntryNode = dataServiceNode.getNode( driverEntryName );
-        assertThat( driverEntryNode.getPrimaryNodeType().getName(), is( DataVirtLexicon.DriverEntry.NODE_TYPE ) );
-        assertThat( driverEntryNode.hasProperty( DataVirtLexicon.DriverEntry.PATH ), is( true ) );
-        assertThat( driverEntryNode.getProperty( DataVirtLexicon.DriverEntry.PATH ).getString(),
+        assertThat( driverEntryNode.getPrimaryNodeType().getName(), is( DataVirtLexicon.ResourceEntry.DRIVER_ENTRY_NODE_TYPE ) );
+        assertThat( driverEntryNode.hasProperty( DataVirtLexicon.ResourceEntry.PATH ), is( true ) );
+        assertThat( driverEntryNode.getProperty( DataVirtLexicon.ResourceEntry.PATH ).getString(),
                     is( "drivers/" + driverEntryName ) );
+        assertThat( driverEntryNode.hasProperty( DataVirtLexicon.ResourceEntry.PUBLISH_POLICY ), is( true ) );
+        assertThat( driverEntryNode.getProperty( DataVirtLexicon.ResourceEntry.PUBLISH_POLICY ).getString(),
+                    is( publishPolicy.name() ) );
 
         // check reference
         assertReferencedResource( driverEntryNode,
-                                  DataVirtLexicon.DriverEntry.DRIVER_REF,
-                                  DataVirtLexicon.DriverFile.NODE_TYPE,
-                                  deployPolicy,
+                                  DataVirtLexicon.ResourceEntry.RESOURCE_REF,
+                                  DataVirtLexicon.ResourceFile.DRIVER_FILE_NODE_TYPE,
+                                  publishPolicy,
                                   true );
     }
 
@@ -122,7 +131,7 @@ public final class DataServiceSequencerTest extends AbstractSequencerTest {
 
     private void assertResource( final Node dataServiceNode,
                                  final String resourceEntryName,
-                                 final DataServiceEntry.PublishPolicy deployPolicy ) throws Exception {
+                                 final DataServiceEntry.PublishPolicy publishPolicy ) throws Exception {
         assertThat( dataServiceNode.hasNode( resourceEntryName ), is( true ) );
 
         final Node resourceEntryNode = dataServiceNode.getNode( resourceEntryName );
@@ -130,48 +139,57 @@ public final class DataServiceSequencerTest extends AbstractSequencerTest {
         assertThat( resourceEntryNode.hasProperty( DataVirtLexicon.ResourceEntry.PATH ), is( true ) );
         assertThat( resourceEntryNode.getProperty( DataVirtLexicon.ResourceEntry.PATH ).getString(),
                     is( "resources/" + resourceEntryName ) );
+        assertThat( resourceEntryNode.hasProperty( DataVirtLexicon.ConnectionEntry.PUBLISH_POLICY ), is( true ) );
+        assertThat( resourceEntryNode.getProperty( DataVirtLexicon.ConnectionEntry.PUBLISH_POLICY ).getString(),
+                    is( publishPolicy.name() ) );
 
         // check reference
         assertReferencedResource( resourceEntryNode,
                                   DataVirtLexicon.ResourceEntry.RESOURCE_REF,
                                   DataVirtLexicon.ResourceFile.NODE_TYPE,
-                                  deployPolicy,
+                                  publishPolicy,
                                   true );
     }
 
     private void assertUdf( final Node dataServiceNode,
                             final String udfEntryName,
-                            final DataServiceEntry.PublishPolicy deployPolicy ) throws Exception {
+                            final DataServiceEntry.PublishPolicy publishPolicy ) throws Exception {
         assertThat( dataServiceNode.hasNode( udfEntryName ), is( true ) );
 
         final Node udfEntryNode = dataServiceNode.getNode( udfEntryName );
-        assertThat( udfEntryNode.getPrimaryNodeType().getName(), is( DataVirtLexicon.ResourceEntry.UDF_FILE_NODE_TYPE ) );
+        assertThat( udfEntryNode.getPrimaryNodeType().getName(), is( DataVirtLexicon.ResourceEntry.UDF_ENTRY_NODE_TYPE ) );
         assertThat( udfEntryNode.hasProperty( DataVirtLexicon.ResourceEntry.PATH ), is( true ) );
         assertThat( udfEntryNode.getProperty( DataVirtLexicon.ResourceEntry.PATH ).getString(), is( "udfs/" + udfEntryName ) );
+        assertThat( udfEntryNode.hasProperty( DataVirtLexicon.ConnectionEntry.PUBLISH_POLICY ), is( true ) );
+        assertThat( udfEntryNode.getProperty( DataVirtLexicon.ConnectionEntry.PUBLISH_POLICY ).getString(),
+                    is( publishPolicy.name() ) );
 
         // check reference
         assertReferencedResource( udfEntryNode,
                                   DataVirtLexicon.ResourceEntry.RESOURCE_REF,
                                   DataVirtLexicon.ResourceFile.UDF_FILE_NODE_TYPE,
-                                  deployPolicy,
+                                  publishPolicy,
                                   true );
     }
 
     private void assertVdb( final Node dataServiceNode,
                             final String vdbEntryName,
-                            final DataServiceEntry.PublishPolicy deployPolicy ) throws Exception {
+                            final DataServiceEntry.PublishPolicy publishPolicy ) throws Exception {
         assertThat( dataServiceNode.hasNode( vdbEntryName ), is( true ) );
 
         final Node vdbEntryNode = dataServiceNode.getNode( vdbEntryName );
         assertThat( vdbEntryNode.getPrimaryNodeType().getName(), is( DataVirtLexicon.VdbEntry.NODE_TYPE ) );
         assertThat( vdbEntryNode.hasProperty( DataVirtLexicon.VdbEntry.PATH ), is( true ) );
         assertThat( vdbEntryNode.getProperty( DataVirtLexicon.VdbEntry.PATH ).getString(), is( "vdbs/" + vdbEntryName ) );
+        assertThat( vdbEntryNode.hasProperty( DataVirtLexicon.ConnectionEntry.PUBLISH_POLICY ), is( true ) );
+        assertThat( vdbEntryNode.getProperty( DataVirtLexicon.ConnectionEntry.PUBLISH_POLICY ).getString(),
+                    is( publishPolicy.name() ) );
 
         // check reference
         assertReferencedResource( vdbEntryNode,
                                   DataVirtLexicon.VdbEntry.VDB_REF,
                                   VdbLexicon.Vdb.VIRTUAL_DATABASE,
-                                  deployPolicy,
+                                  publishPolicy,
                                   false );
     }
 
@@ -235,8 +253,13 @@ public final class DataServiceSequencerTest extends AbstractSequencerTest {
 
             final Node serviceVdbEntryNode = outputNode.getNode( serviceVdbPath );
             assertThat( serviceVdbEntryNode.getPrimaryNodeType().getName(), is( DataVirtLexicon.ServiceVdbEntry.NODE_TYPE ) );
-            assertThat( serviceVdbEntryNode.hasProperty( DataVirtLexicon.DriverEntry.PATH ), is( true ) );
-            assertThat( serviceVdbEntryNode.getProperty( DataVirtLexicon.DriverEntry.PATH ).getString(), is( serviceVdbPath ) );
+            assertThat( serviceVdbEntryNode.hasProperty( DataVirtLexicon.ResourceEntry.PATH ), is( true ) );
+            assertThat( serviceVdbEntryNode.getProperty( DataVirtLexicon.ResourceEntry.PATH ).getString(), is( serviceVdbPath ) );
+            assertThat( serviceVdbEntryNode.hasProperty( DataVirtLexicon.ServiceVdbEntry.VDB_NAME ), is( true ) );
+            assertThat( serviceVdbEntryNode.getProperty( DataVirtLexicon.ServiceVdbEntry.VDB_NAME ).getString(),
+                        is( "ServiceVdb" ) ); // name from manifest
+            assertThat( serviceVdbEntryNode.hasProperty( DataVirtLexicon.ServiceVdbEntry.VDB_VERSION ), is( true ) );
+            assertThat( serviceVdbEntryNode.getProperty( DataVirtLexicon.ServiceVdbEntry.VDB_VERSION ).getString(), is( "1" ) );
 
             // check reference
             assertReferencedResource( serviceVdbEntryNode,

--- a/sequencers/teiid-modeshape-sequencer-vdb/src/main/java/org/teiid/modeshape/sequencer/vdb/VdbSequencer.java
+++ b/sequencers/teiid-modeshape-sequencer-vdb/src/main/java/org/teiid/modeshape/sequencer/vdb/VdbSequencer.java
@@ -273,9 +273,7 @@ public class VdbSequencer extends Sequencer {
     public void initialize( final NamespaceRegistry registry,
                             final NodeTypeManager nodeTypeManager ) throws RepositoryException, IOException {
         LOGGER.debug("enter initialize");
-//        registry.registerNamespace(VdbLexicon.Namespace.PREFIX, VdbLexicon.Namespace.URI);
-//        registry.registerNamespace(XmiLexicon.Namespace.PREFIX, XmiLexicon.Namespace.URI);
-//        registry.registerNamespace(CoreLexicon.Namespace.PREFIX, CoreLexicon.Namespace.URI);
+        
         registerNodeTypes("xmi.cnd", nodeTypeManager, true);
         LOGGER.debug("xmi.cnd loaded");
 

--- a/sequencers/teiid-modeshape-sequencer-vdb/src/main/resources/org/teiid/modeshape/sequencer/vdb/vdb.cnd
+++ b/sequencers/teiid-modeshape-sequencer-vdb/src/main/resources/org/teiid/modeshape/sequencer/vdb/vdb.cnd
@@ -34,13 +34,14 @@
 // N O D E T Y P E S
 //------------------------------------------------------------------------------
 
-[vdb:virtualDatabase] > nt:unstructured, mode:hashed
+[vdb:virtualDatabase] > nt:unstructured, mode:hashed, mix:referenceable
  - vdb:name (string)
  - vdb:description (string) 
  - vdb:version (long) = '1' autocreated
  - vdb:preview (boolean) = 'false' autocreated
  - vdb:connectionType (string)
  - vdb:originalFile (string)
+ + * (vdb:abstractModel) copy
  + vdb:translators (vdb:translators) copy
  + vdb:dataRoles (vdb:dataRoles) copy
  + vdb:entries (vdb:entries) copy

--- a/sequencers/teiid-modeshape-sequencer-vdb/src/test/java/org/teiid/modeshape/sequencer/vdb/VdbSequencerTest.java
+++ b/sequencers/teiid-modeshape-sequencer-vdb/src/test/java/org/teiid/modeshape/sequencer/vdb/VdbSequencerTest.java
@@ -144,6 +144,7 @@ public final class VdbSequencerTest extends AbstractSequencerTest {
         Node outputNode = getOutputNode(this.rootNode, "vdbs/BooksVDB.vdb");
         assertNotNull(outputNode);
         assertThat(outputNode.getPrimaryNodeType().getName(), is(VdbLexicon.Vdb.VIRTUAL_DATABASE));
+        assertThat(outputNode.isNodeType( JcrConstants.MIX_REFERENCEABLE ), is(true));
 
         // check properties
         assertThat(outputNode.getProperty(VdbLexicon.Vdb.DESCRIPTION).getString(), is("This is a VDB description"));


### PR DESCRIPTION
- fixed issue of loading data service and connection XSDs for validation
- changed terminology to "connection" instead of "datasource" in more places
- now persisting the "publishPolicy" property of a data service entry
- moved driver, DDL, and UDF lexicon constants to the ResourceEntry and ResourceFile interfaces
- changed the driver, DDL, and UDF file CND node types to now extend the resource file node type
- merged a change to vdb.cnd that Komodo had made. In a Komodo PR will be deleting the shared CNDs from it's codebase.