### PR TITLE
TEIIDTOOLS-31 StandardDdlParser needs to allow turning includeComments ON or OFF

### DIFF
--- a/sequencers/teiid-modeshape-sequencer-ddl/src/main/java/org/teiid/modeshape/sequencer/ddl/TeiidDdlParser.java
+++ b/sequencers/teiid-modeshape-sequencer-ddl/src/main/java/org/teiid/modeshape/sequencer/ddl/TeiidDdlParser.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.teiid.modeshape.sequencer.ddl.DdlTokenStream.DdlTokenizer;
 import org.teiid.modeshape.sequencer.ddl.node.AstNode;
 
 /**
@@ -148,6 +149,9 @@ public final class TeiidDdlParser extends StandardDdlParser implements TeiidDdlC
                 return statementNode;
             }
         }
+        
+        // don't consume comment as super will do that for ignorable statements
+        if (tokens.matches(DdlTokenizer.COMMENT)) return null; // TODO these comments are being thrown out
 
         // Unparsable DDL statement
         throw new TeiidDdlParsingException(tokens, "Unparsable DDL statement");

--- a/sequencers/teiid-modeshape-sequencer-ddl/src/main/resources/org/teiid/modeshape/sequencer/ddl/StandardDdl.cnd
+++ b/sequencers/teiid-modeshape-sequencer-ddl/src/main/resources/org/teiid/modeshape/sequencer/ddl/StandardDdl.cnd
@@ -40,7 +40,7 @@
 // =============================================================================
 // STATEMENT
 // =============================================================================
-[ddl:statement] mixin abstract
+[ddl:statement] mixin
   - ddl:expression (string) mandatory                       // The string fragment encompassing the statement expression.
   - ddl:originalExpression (string)               // The string fragment encompassing the original statement expression.
   - ddl:startLineNumber (long) mandatory                    // The starting line number for the statement

--- a/sequencers/teiid-modeshape-sequencer-ddl/src/test/java/org/teiid/modeshape/sequencer/ddl/CreateProcedureParserTest.java
+++ b/sequencers/teiid-modeshape-sequencer-ddl/src/test/java/org/teiid/modeshape/sequencer/ddl/CreateProcedureParserTest.java
@@ -133,7 +133,6 @@ public class CreateProcedureParserTest extends TeiidDdlTest {
     /**
      * See Teiid TestDDLParser#testPushdownFunctionNoArgs()
      */
-    @SuppressWarnings( "null" )
     @Test
     public void shouldParsePushdownFunctionNoArgs() {
         final String content = "CREATE FOREIGN FUNCTION SourceFunc() RETURNS integer OPTIONS (UUID 'hello world')";

--- a/sequencers/teiid-modeshape-sequencer-ddl/src/test/java/org/teiid/modeshape/sequencer/ddl/TeiidDdlParserTest.java
+++ b/sequencers/teiid-modeshape-sequencer-ddl/src/test/java/org/teiid/modeshape/sequencer/ddl/TeiidDdlParserTest.java
@@ -100,6 +100,105 @@ public class TeiidDdlParserTest extends DdlParserTestHelper implements TeiidDdlC
             assertMixinType(kids.get(0), TeiidDdlLexicon.CreateProcedure.PROCEDURE_STATEMENT);
         }
     }
+    
+    @Test
+    public void shouldKeepCacheHints() {
+	// @formatter :off
+	final String content = "CREATE VIEW internal_short_ttl (\n" 
+	        + "\tcustomer_id integer NOT NULL,\n"
+		+ "\ttotal_amount integer\n" 
+	        + ") OPTIONS (MATERIALIZED 'TRUE',\n"
+		+ "\t\"teiid_rel:MATVIEW_BEFORE_LOAD_SCRIPT\" 'execute Source.native(''INSERT INTO check_table(id,before_load) VALUES (''internal_short_ttl'',1) ON DUPLICATE KEY UPDATE before_load=before_load+1;'');',\n"
+		+ "\t\"teiid_rel:MATVIEW_AFTER_LOAD_SCRIPT\" 'execute Source.native(''INSERT INTO check_table(id,after_load) VALUES (''internal_short_ttl'',1) ON DUPLICATE KEY UPDATE after_load=after_load+1;'')'\n"
+		+ ")\n"
+		+ "\tAS /*+ cache(ttl:100)*/SELECT c.id AS customer_id, CONVERT(SUM(o.amount),biginteger) AS total_amount FROM customers c INNER JOIN orders o ON c.id = o.customer_id GROUP BY c.id;";
+	// @formatter :on
+	assertScoreAndParse(content, null, 1);
+
+	final List<AstNode> kids = getRootNode().childrenWithName("internal_short_ttl");
+	assertThat(kids.size(), is(1));
+	assertMixinType(kids.get(0), TeiidDdlLexicon.CreateTable.VIEW_STATEMENT);
+
+	final AstNode viewNode = kids.get(0);
+	assertProperty(viewNode, TeiidDdlLexicon.CreateTable.QUERY_EXPRESSION,
+		"/*+ cache(ttl:100)*/SELECT c.id AS customer_id, CONVERT(SUM(o.amount),biginteger) AS total_amount FROM customers c INNER JOIN orders o ON c.id = o.customer_id GROUP BY c.id");
+    }
+
+    @Test
+    public void shouldKeepDdlComments() {
+	final String content = "CREATE VIEW PRODUCTDATA (\n"
+		+ "\tINSTR_ID string(10) NOT NULL OPTIONS(NAMEINSOURCE '\"INSTR_ID\"', NATIVE_TYPE 'VARCHAR2', UPDATABLE 'FALSE'),\n"
+		+ "\tNAME string(60) OPTIONS(NAMEINSOURCE '\"NAME\"', NATIVE_TYPE 'VARCHAR2', UPDATABLE 'FALSE'),\n"
+		+ "\tTYPE string(15) OPTIONS(NAMEINSOURCE '\"TYPE\"', NATIVE_TYPE 'VARCHAR2', UPDATABLE 'FALSE'),\n"
+		+ "\tISSUER string(10) OPTIONS(NAMEINSOURCE '\"ISSUER\"', NATIVE_TYPE 'VARCHAR2', UPDATABLE 'FALSE'),\n"
+		+ "\tEXCHANGE string(10) OPTIONS(NAMEINSOURCE '\"EXCHANGE\"', NATIVE_TYPE 'VARCHAR2', UPDATABLE 'FALSE'),\n"
+		+ "\tISDJI bigdecimal(22) NOT NULL OPTIONS(NAMEINSOURCE '\"ISDJI\"', NATIVE_TYPE 'NUMBER', CASE_SENSITIVE 'FALSE', UPDATABLE 'FALSE', FIXED_LENGTH 'TRUE', SEARCHABLE 'ALL_EXCEPT_LIKE'),\n"
+		+ "\tISSP500 bigdecimal(22) NOT NULL OPTIONS(NAMEINSOURCE '\"ISSP500\"', NATIVE_TYPE 'NUMBER', CASE_SENSITIVE 'FALSE', UPDATABLE 'FALSE', FIXED_LENGTH 'TRUE', SEARCHABLE 'ALL_EXCEPT_LIKE'),\n"
+		+ "\tISNAS100 bigdecimal(22) NOT NULL OPTIONS(NAMEINSOURCE '\"ISNAS100\"', NATIVE_TYPE 'NUMBER', CASE_SENSITIVE 'FALSE', UPDATABLE 'FALSE', FIXED_LENGTH 'TRUE', SEARCHABLE 'ALL_EXCEPT_LIKE'),\n"
+		+ "\tISAMEXINT bigdecimal(22) NOT NULL OPTIONS(NAMEINSOURCE '\"ISAMEXINT\"', NATIVE_TYPE 'NUMBER', CASE_SENSITIVE 'FALSE', UPDATABLE 'FALSE', FIXED_LENGTH 'TRUE', SEARCHABLE 'ALL_EXCEPT_LIKE'),\n"
+		+ "\tPRIBUSINESS string(30) OPTIONS(NAMEINSOURCE '\"PRIBUSINESS\"', NATIVE_TYPE 'VARCHAR2', UPDATABLE 'FALSE'),\n"
+		+ "\tCONSTRAINT PK_PD_INSTR_ID PRIMARY KEY(INSTR_ID)\n"
+		+ ") OPTIONS(NAMEINSOURCE '\"PRODUCTS\".\"PRODUCTDATA\"', UPDATABLE 'FALSE') \n" + "AS\n"
+		+ "\t/* first comment in the product data*/\n" + "SELECT\n" + "\t\t*\n" + "\tFROM\n"
+		+ "\t\t/* second comment in the product data*/\n" + "\t\tProducts.PRODUCTDATA;\n" + "\t\t\n"
+		+ "CREATE VIEW PRODUCTSYMBOLS (\n"
+		+ "\tINSTR_ID string(10) NOT NULL OPTIONS(NAMEINSOURCE '\"INSTR_ID\"', NATIVE_TYPE 'VARCHAR2', UPDATABLE 'FALSE'),\n"
+		+ "\tSYMBOL_TYPE bigdecimal(22) OPTIONS(NAMEINSOURCE '\"SYMBOL_TYPE\"', NATIVE_TYPE 'NUMBER', CASE_SENSITIVE 'FALSE', UPDATABLE 'FALSE', FIXED_LENGTH 'TRUE', SEARCHABLE 'ALL_EXCEPT_LIKE'),\n"
+		+ "\tSYMBOL string(10) NOT NULL OPTIONS(NAMEINSOURCE '\"SYMBOL\"', NATIVE_TYPE 'VARCHAR2', UPDATABLE 'FALSE'),\n"
+		+ "\tCUSIP string(10) OPTIONS(NAMEINSOURCE '\"CUSIP\"', NATIVE_TYPE 'VARCHAR2', UPDATABLE 'FALSE'),\n"
+		+ "\tCONSTRAINT PK_PS_INSTR_ID PRIMARY KEY(INSTR_ID),\n"
+		+ "\tCONSTRAINT FK_INSTR_ID FOREIGN KEY(INSTR_ID) REFERENCES PRODUCTDATA(INSTR_ID)\n"
+		+ ") OPTIONS(NAMEINSOURCE '\"PRODUCTS\".\"PRODUCTSYMBOLS\"', UPDATABLE 'FALSE') \n" + "AS\n"
+		+ "\t/* first comment in the product symbols*/\n" + "SELECT\n" + "\t\t*\n" + "\tFROM\n"
+		+ "\t\t/* second comment in the product symbols*/\n" + "\t\tProducts.PRODUCTSYMBOLS;\n" + "\t\t\n"
+		+ "CREATE VIEW TYPETEST (\n"
+		+ "\tCUSTOMERID string(12) NOT NULL OPTIONS(NAMEINSOURCE '\"CUSTOMERID\"', NATIVE_TYPE 'VARCHAR2', UPDATABLE 'FALSE'),\n"
+		+ "\tDATECOL date NOT NULL OPTIONS(NAMEINSOURCE '\"DATECOL\"', NATIVE_TYPE 'DATE', CASE_SENSITIVE 'FALSE', UPDATABLE 'FALSE', FIXED_LENGTH 'TRUE', SEARCHABLE 'ALL_EXCEPT_LIKE'),\n"
+		+ "\tDATETIMECOL timestamp NOT NULL OPTIONS(NAMEINSOURCE '\"DATETIMECOL\"', NATIVE_TYPE 'TIMESTAMP(6)', CASE_SENSITIVE 'FALSE', UPDATABLE 'FALSE', FIXED_LENGTH 'TRUE', SEARCHABLE 'ALL_EXCEPT_LIKE'),\n"
+		+ "\tTIMESTAMPWITHTZ timestamp OPTIONS(NAMEINSOURCE '\"TIMESTAMPWITHTZ\"', NATIVE_TYPE 'TIMESTAMP(6) WITH TIME ZONE', CASE_SENSITIVE 'FALSE', UPDATABLE 'FALSE', FIXED_LENGTH 'TRUE', SEARCHABLE 'ALL_EXCEPT_LIKE'),\n"
+		+ "\tTIMESTAMP2WITHTZ timestamp OPTIONS(NAMEINSOURCE '\"TIMESTAMP2WITHTZ\"', NATIVE_TYPE 'TIMESTAMP(6) WITH TIME ZONE', CASE_SENSITIVE 'FALSE', UPDATABLE 'FALSE', FIXED_LENGTH 'TRUE', SEARCHABLE 'ALL_EXCEPT_LIKE'),\n"
+		+ "\tDOUBLECOL float NOT NULL OPTIONS(NAMEINSOURCE '\"DOUBLECOL\"', NATIVE_TYPE 'FLOAT', CASE_SENSITIVE 'FALSE', UPDATABLE 'FALSE', FIXED_LENGTH 'TRUE', SEARCHABLE 'ALL_EXCEPT_LIKE'),\n"
+		+ "\tDECIMAL3COL bigdecimal(3) NOT NULL OPTIONS(NAMEINSOURCE '\"DECIMAL3COL\"', NATIVE_TYPE 'NUMBER', CASE_SENSITIVE 'FALSE', UPDATABLE 'FALSE', FIXED_LENGTH 'TRUE', SEARCHABLE 'ALL_EXCEPT_LIKE'),\n"
+		+ "\tDECIMAL22COL bigdecimal(22) NOT NULL OPTIONS(NAMEINSOURCE '\"DECIMAL22COL\"', NATIVE_TYPE 'NUMBER', CASE_SENSITIVE 'FALSE', UPDATABLE 'FALSE', FIXED_LENGTH 'TRUE', SEARCHABLE 'ALL_EXCEPT_LIKE'),\n"
+		+ "\tBIGSTRINGCOL string(512) NOT NULL OPTIONS(NAMEINSOURCE '\"BIGSTRINGCOL\"', NATIVE_TYPE 'VARCHAR2', UPDATABLE 'FALSE'),\n"
+		+ "\tDECIMAL12COL bigdecimal(12) NOT NULL OPTIONS(NAMEINSOURCE '\"DECIMAL12COL\"', NATIVE_TYPE 'NUMBER', CASE_SENSITIVE 'FALSE', UPDATABLE 'FALSE', FIXED_LENGTH 'TRUE', SEARCHABLE 'ALL_EXCEPT_LIKE'),\n"
+		+ "\tINTEGERCOL bigdecimal(22) NOT NULL OPTIONS(NAMEINSOURCE '\"INTEGERCOL\"', NATIVE_TYPE 'NUMBER', CASE_SENSITIVE 'FALSE', UPDATABLE 'FALSE', FIXED_LENGTH 'TRUE', SEARCHABLE 'ALL_EXCEPT_LIKE'),\n"
+		+ "\tDECIMAL22D2COL bigdecimal(22, 2) NOT NULL OPTIONS(NAMEINSOURCE '\"DECIMAL22D2COL\"', NATIVE_TYPE 'NUMBER', CASE_SENSITIVE 'FALSE', UPDATABLE 'FALSE', FIXED_LENGTH 'TRUE', SEARCHABLE 'ALL_EXCEPT_LIKE')\n"
+		+ ") OPTIONS(NAMEINSOURCE '\"PRODUCTS\".\"TYPETEST\"', UPDATABLE 'FALSE') \n" + "AS\n"
+		+ "\t/* first comment in the typetest*/\n" + "SELECT\n" + "\t\t*\n" + "\tFROM\n"
+		+ "\t\t/* second comment in the typetest*/\n" + "\t\tProducts.TYPETEST;";
+	assertScoreAndParse(content, null, 3);
+
+	{
+	    final List<AstNode> kids = getRootNode().childrenWithName("PRODUCTDATA");
+	    assertThat(kids.size(), is(1));
+	    assertMixinType(kids.get(0), TeiidDdlLexicon.CreateTable.VIEW_STATEMENT);
+
+	    final AstNode viewNode = kids.get(0);
+	    assertProperty(viewNode, TeiidDdlLexicon.CreateTable.QUERY_EXPRESSION,
+		    "/* first comment in the product data*/ SELECT * FROM /* second comment in the product data*/ Products.PRODUCTDATA");
+	}
+
+	{
+	    final List<AstNode> kids = getRootNode().childrenWithName("PRODUCTSYMBOLS");
+	    assertThat(kids.size(), is(1));
+	    assertMixinType(kids.get(0), TeiidDdlLexicon.CreateTable.VIEW_STATEMENT);
+
+	    final AstNode viewNode = kids.get(0);
+	    assertProperty(viewNode, TeiidDdlLexicon.CreateTable.QUERY_EXPRESSION,
+		    "/* first comment in the product symbols*/ SELECT * FROM /* second comment in the product symbols*/ Products.PRODUCTSYMBOLS");
+	}
+
+	{
+	    final List<AstNode> kids = getRootNode().childrenWithName("TYPETEST");
+	    assertThat(kids.size(), is(1));
+	    assertMixinType(kids.get(0), TeiidDdlLexicon.CreateTable.VIEW_STATEMENT);
+
+	    final AstNode viewNode = kids.get(0);
+	    assertProperty(viewNode, TeiidDdlLexicon.CreateTable.QUERY_EXPRESSION,
+		    "/* first comment in the typetest*/ SELECT * FROM /* second comment in the typetest*/ Products.TYPETEST");
+	}
+    }
 
     /**
      * See Teiid TestDDLParser#testMultipleCommands2()
@@ -380,7 +479,7 @@ public class TeiidDdlParserTest extends DdlParserTestHelper implements TeiidDdlC
         printTest("shouldSapHana()");
 
         String content = getFileContent(DDL_FILE_PATH + "sap-hana.ddl");
-        assertScoreAndParse(content, "teiid_test_statements_2", 2);
+        assertScoreAndParse(content, "teiid_test_statements_2", 5); // 2 tables + 3 ignorable comments 
         
         { // test for parsing column named INDEX
             final List<AstNode> tables = getRootNode().childrenWithName("_SYS_STATISTICS.GLOBAL_COLUMN_TABLES_SIZE");

--- a/sequencers/teiid-modeshape-sequencer-ddl/src/test/java/org/teiid/modeshape/sequencer/ddl/TeiidDdlSequencerTest.java
+++ b/sequencers/teiid-modeshape-sequencer-ddl/src/test/java/org/teiid/modeshape/sequencer/ddl/TeiidDdlSequencerTest.java
@@ -724,7 +724,7 @@ public class TeiidDdlSequencerTest extends AbstractDdlSequencerTest {
     @Test
     public void shouldSequenceLocalTemporaryTable() throws Exception {
         this.statementsNode = sequenceDdl("ddl/localTemporaryTable.ddl");
-        assertThat(this.statementsNode.getNodes().getSize(), is(2L)); // create table, create temp table
+        assertThat(this.statementsNode.getNodes().getSize(), is(3L)); // create table, create temp table, ignored comment
 
         final Node tempTableNode = this.statementsNode.getNode("x");
         verifyMixinType(tempTableNode, TeiidDdlLexicon.CreateTable.LOCAL_TEMP_TABLE_STATEMENT);
@@ -751,6 +751,10 @@ public class TeiidDdlSequencerTest extends AbstractDdlSequencerTest {
         } else {
             fail();
         }
+        
+        final Node ignored = this.statementsNode.getNode("IGNORED_1");
+        assertThat(ignored.getProperty(StandardDdlLexicon.DDL_EXPRESSION).getString(),
+                   is("// this first statement is needed so that the Teiid parser is picked"));
     }
 
     @Ignore


### PR DESCRIPTION
- Comments found in model metadata/model definition are not saved in the the teiiddl:modelDefinition property
- Comments found in the DDL are now saved as ignorable statements and have names that start with "IGNORED_x" with "x" being a numeric index.
- Added tests to make sure cache hints are kept, SQL comments are kept, and beginning DDL comments are kept.