### PR TITLE
Issue 31 VDB and Connection Data Service Entry Names Should Have Correct Suffix

### DIFF
--- a/sequencers/teiid-modeshape-sequencer-dataservice/src/main/java/org/teiid/modeshape/sequencer/dataservice/ConnectionReader.java
+++ b/sequencers/teiid-modeshape-sequencer-dataservice/src/main/java/org/teiid/modeshape/sequencer/dataservice/ConnectionReader.java
@@ -52,11 +52,6 @@ import org.xml.sax.helpers.DefaultHandler;
  */
 public final class ConnectionReader extends DefaultHandler {
 
-    /**
-     * The valid connection file extension. Value is {@value}.
-     */
-    public static final String FILE_EXTENSION = "-connection.xml"; //$NON-NLS-1$
-
     private static final String DATA_SOURCE_SCHEMA_FILE = "connection.xsd"; //$NON-NLS-1$
     private static final Logger LOGGER = Logger.getLogger( ConnectionReader.class );
 

--- a/sequencers/teiid-modeshape-sequencer-dataservice/src/main/java/org/teiid/modeshape/sequencer/dataservice/DataServiceExporter.java
+++ b/sequencers/teiid-modeshape-sequencer-dataservice/src/main/java/org/teiid/modeshape/sequencer/dataservice/DataServiceExporter.java
@@ -71,7 +71,7 @@ public class DataServiceExporter extends AbstractExporter {
     /**
      * The result data key whose value is a <code>String[]</code> of the file entry paths of the result outcome. Used only when
      * exporting file contents of the data service.
-     * 
+     *
      * @see Result#getData(String)
      * @see Result#getOutcome()
      */
@@ -938,8 +938,25 @@ public class DataServiceExporter extends AbstractExporter {
             } else if ( StringUtil.isBlank( entryFolder ) ) {
                 path = node.getName();
             } else {
-                path = ( entryFolder
-                         + node.getName() );
+                path = ( entryFolder + ( entryFolder.endsWith( "/" ) ? node.getName() : ( '/' + node.getName() ) ) );
+            }
+
+            // ensure VDB and connection entry paths have the required suffix
+            if ( ( ( entry instanceof VdbEntry ) || ( entry instanceof ServiceVdbEntry ) )
+                    && ( !path.endsWith( DataServiceManifest.VDB_ENTRY_SUFFIX ) ) ) {
+                if ( path.endsWith( ".xml" ) ) {
+                    path = ( path.substring( 0, path.lastIndexOf( ".xml" ) ) + DataServiceManifest.VDB_ENTRY_SUFFIX );
+                } else {
+                    path = ( path + DataServiceManifest.VDB_ENTRY_SUFFIX );
+                }
+            } else if ( ( entry instanceof ConnectionEntry )
+                    && ( !path.endsWith( DataServiceManifest.CONNECTION_ENTRY_SUFFIX ) ) ) {
+                if ( path.endsWith( ".xml" ) ) {
+                    path = ( path.substring( 0, path.lastIndexOf( ".xml" ) )
+                            + DataServiceManifest.CONNECTION_ENTRY_SUFFIX );
+                } else {
+                    path = ( path + DataServiceManifest.CONNECTION_ENTRY_SUFFIX );
+                }
             }
 
             entry.setPath( path );

--- a/sequencers/teiid-modeshape-sequencer-dataservice/src/main/java/org/teiid/modeshape/sequencer/dataservice/DataServiceManifest.java
+++ b/sequencers/teiid-modeshape-sequencer-dataservice/src/main/java/org/teiid/modeshape/sequencer/dataservice/DataServiceManifest.java
@@ -37,6 +37,11 @@ import org.modeshape.common.util.StringUtil;
 public class DataServiceManifest implements VdbEntryContainer {
 
     /**
+     * The required connection entry suffix. Value is {@value}.
+     */
+    public static final String CONNECTION_ENTRY_SUFFIX = "-connection.xml";
+
+    /**
      * The date pattern used for the last modified property.
      */
     public static final String DATE_PATTERN = "yyyy-MM-dd'T'HH:mm:ss";
@@ -55,6 +60,11 @@ public class DataServiceManifest implements VdbEntryContainer {
      * The entry path of the data service manifest.
      */
     public static final String MANIFEST_ZIP_PATH = ( "META-INF/" + MANIFEST_FILE );
+
+    /**
+     * The required VDB entry suffix. Value is {@value}.
+     */
+    public static final String VDB_ENTRY_SUFFIX = "-vdb.xml";
 
     /**
      * @param lastModifiedDate the string representation of the date being parsed (cannot be <code>null</code>)

--- a/sequencers/teiid-modeshape-sequencer-dataservice/src/test/java/org/teiid/modeshape/sequencer/dataservice/DataServiceExporterTest.java
+++ b/sequencers/teiid-modeshape-sequencer-dataservice/src/test/java/org/teiid/modeshape/sequencer/dataservice/DataServiceExporterTest.java
@@ -22,6 +22,8 @@
 
 package org.teiid.modeshape.sequencer.dataservice;
 
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.hamcrest.core.IsNot.not;
@@ -39,12 +41,15 @@ import java.util.List;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 import javax.jcr.Node;
+import javax.jcr.NodeIterator;
+import javax.jcr.Value;
 import org.junit.Test;
 import org.teiid.modeshape.sequencer.AbstractSequencerTest;
 import org.teiid.modeshape.sequencer.Options;
 import org.teiid.modeshape.sequencer.Result;
 import org.teiid.modeshape.sequencer.dataservice.DataServiceExporter.ExportArtifact;
 import org.teiid.modeshape.sequencer.dataservice.DataServiceExporter.OptionName;
+import org.teiid.modeshape.sequencer.dataservice.lexicon.DataVirtLexicon;
 import org.teiid.modeshape.sequencer.vdb.VdbManifest;
 import org.teiid.modeshape.sequencer.vdb.VdbModel;
 
@@ -67,6 +72,77 @@ public final class DataServiceExporterTest extends AbstractSequencerTest {
     @Override
     protected InputStream getRepositoryConfigStream() {
         return resourceStream( "config/repo-config.json" );
+    }
+
+    @Test
+    public void shouldCorrectVdbAndConnectionEntryNames() throws Exception {
+        final Node dsNode = this.rootNode.addNode( "MyDataService", DataVirtLexicon.DataService.NODE_TYPE );
+        final String serviceVdbEntryName = "MyServiceVdb";
+        final String connectionEntryPath = "ResourceConnection";
+
+        { // add service VDB entry
+          // import and sequence VDB
+            createNodeWithContentFromFile( "patients-vdb.xml", "vdbs/patients-vdb.xml" );
+            final Node serviceVdbNode = getOutputNode( this.rootNode, "vdbs/patients-vdb.xml" );
+            final String refId = serviceVdbNode.getIdentifier();
+
+            // don't set path and the entry name will be used for the path
+            final Node entryNode = dsNode.addNode( serviceVdbEntryName, DataVirtLexicon.ServiceVdbEntry.NODE_TYPE );
+            entryNode.setProperty( DataVirtLexicon.ServiceVdbEntry.VDB_REF, refId );
+            entryNode.setProperty( DataVirtLexicon.ServiceVdbEntry.VDB_NAME, "patients" );
+            entryNode.setProperty( DataVirtLexicon.ServiceVdbEntry.VDB_VERSION, "1" );
+        }
+
+        { // add connection entry
+          // import and sequence connection
+            createNodeWithContentFromFile( "resource-connection.xml", "connections/resource-connection.xml" );
+            final Node connectionNode = getOutputNode( this.rootNode, "connections/resourceConnection" );
+            final String refId = connectionNode.getIdentifier();
+
+            final Node connectionEntryNode = dsNode.addNode( "ResourceConnectionEntry",
+                    DataVirtLexicon.ConnectionEntry.NODE_TYPE );
+            // set path but it doesn't have the right suffix
+            connectionEntryNode.setProperty( DataVirtLexicon.ConnectionEntry.PATH, connectionEntryPath );
+            connectionEntryNode.setProperty( DataVirtLexicon.ConnectionEntry.CONNECTION_REF, refId );
+            connectionEntryNode.setProperty( DataVirtLexicon.ConnectionEntry.JDNI_NAME, "java:/jndiName" );
+        }
+
+        { // add VDB entry
+          // import and sequence VDB
+            createNodeWithContentFromFile( "product-view-vdb.xml", "vdbs/product-view-vdb.xml" );
+            final Node vdbNode = getOutputNode( this.rootNode, "vdbs/product-view-vdb.xml" );
+            final String refId = vdbNode.getIdentifier();
+
+            final Node entryNode = dsNode.addNode( "ProductViewVdbEntry", DataVirtLexicon.VdbEntry.NODE_TYPE );
+            // set path to right extension but not the right complete suffix
+            entryNode.setProperty( DataVirtLexicon.VdbEntry.PATH, "product-view.xml" );
+            entryNode.setProperty( DataVirtLexicon.VdbEntry.VDB_REF, refId );
+            entryNode.setProperty( DataVirtLexicon.VdbEntry.VDB_NAME, "DynamicProducts" );
+            entryNode.setProperty( DataVirtLexicon.VdbEntry.VDB_VERSION, "2" );
+        }
+
+        // export
+        final DataServiceExporter exporter = new DataServiceExporter();
+        final Options options = new Options();
+        options.set( OptionName.EXPORT_ARTIFACT, ExportArtifact.MANIFEST_AS_XML );
+        final Result result = exporter.execute( dsNode, options );
+        assertThat( result.wasSuccessful(), is( true ) );
+
+        // read back in as a manifest
+        final String xml = ( String ) result.getOutcome();
+        final DataServiceManifestReader reader = new DataServiceManifestReader();
+        final DataServiceManifest manifest = reader.read( new ByteArrayInputStream( xml.getBytes() ) );
+        assertThat( manifest, is( notNullValue() ) );
+
+        // test entry paths
+        assertThat( manifest.getServiceVdb(), is( notNullValue() ) );
+        assertThat( manifest.getServiceVdb().getEntryName(),
+                is( serviceVdbEntryName + DataServiceManifest.VDB_ENTRY_SUFFIX ) );
+        assertThat( manifest.getConnections().length, is( 1 ) );
+        assertThat( manifest.getConnections()[ 0 ].getEntryName(),
+                is( connectionEntryPath + DataServiceManifest.CONNECTION_ENTRY_SUFFIX ) );
+        assertThat( manifest.getVdbs().length, is( 1 ) );
+        assertThat( manifest.getVdbs()[ 0 ].getEntryName(), is( "product-view-vdb.xml" ) );
     }
 
     @Test
@@ -174,6 +250,104 @@ public final class DataServiceExporterTest extends AbstractSequencerTest {
                         + paths.toString(),
                         paths.isEmpty(),
                         is( true ) );
+        }
+    }
+
+    @Test
+    public void shouldExportDataServiceInSpecifiedFolders() throws Exception {
+        createNodeWithContentFromFile( "MyDataService.zip", "dataservice/sample-ds.zip" );
+        final Node dataServiceNode = getOutputNode( this.rootNode, "dataservices/MyDataService.zip" );
+        assertThat( dataServiceNode, is( notNullValue() ) );
+
+        { // need to unset the entry path property since it was set during sequencing
+            final NodeIterator itr = dataServiceNode.getNodes();
+
+            while (itr.hasNext()) {
+                final Node entry = itr.nextNode();
+                entry.setProperty( DataVirtLexicon.DataServiceEntry.PATH, ( Value ) null );
+
+                // clear dependency VDB paths
+                if ( DataVirtLexicon.ServiceVdbEntry.NODE_TYPE.equals( entry.getPrimaryNodeType().getName() ) ) {
+                    final NodeIterator depItr = entry.getNodes();
+
+                    while (depItr.hasNext()) {
+                        final Node dependency = depItr.nextNode();
+                        dependency.setProperty( DataVirtLexicon.DataServiceEntry.PATH, ( Value ) null );
+                    }
+                }
+            }
+        }
+
+        final String connectionsFolder = "TEST-connections/";
+        final String driversFolder = "TEST-drivers/";
+        final String metadataFolder = "TEST-metadata/";
+        final String resourcesFolder = "TEST-resources/";
+        final String udfsFolder = "TEST-udfs/";
+        final String vdbsFolder = "TEST-vdbs/";
+
+        final Options options = new Options();
+        options.set( OptionName.EXPORT_ARTIFACT, ExportArtifact.MANIFEST_AS_XML );
+        options.set( OptionName.CONNECTIONS_FOLDER, connectionsFolder );
+        options.set( OptionName.DRIVERS_EXPORT_FOLDER, driversFolder );
+        options.set( OptionName.METADATA_FOLDER, metadataFolder );
+        options.set( OptionName.RESOURCES_FOLDER, resourcesFolder );
+        options.set( OptionName.UDFS_FOLDER, udfsFolder );
+        options.set( OptionName.VDBS_FOLDER, vdbsFolder );
+
+        final DataServiceExporter exporter = new DataServiceExporter();
+        final Result result = exporter.execute( dataServiceNode, options );
+        assertThat( result, is( notNullValue() ) );
+        assertThat( result.getError(), is( nullValue() ) );
+        assertThat( result.getErrorMessage(), is( nullValue() ) );
+        assertThat( result.getOutcome(), is( instanceOf( result.getType() ) ) );
+
+        final String xml = ( String ) result.getOutcome();
+        final DataServiceManifestReader reader = new DataServiceManifestReader();
+        final DataServiceManifest manifest = reader.read( new ByteArrayInputStream( xml.getBytes() ) );
+        assertThat( manifest, is( notNullValue() ) );
+
+        { // service VDB
+            final ServiceVdbEntry serviceVdbEntry = manifest.getServiceVdb();
+            // service VDBs are not put inside the VDBs folder
+            assertThat( serviceVdbEntry.getPath(), is( "product-view-vdb.xml" ) );
+        }
+
+        { // connections
+            final String[] paths = manifest.getConnectionPaths();
+            assertThat( Arrays.asList( paths ), hasItems( connectionsFolder + "books-connection.xml",
+                    connectionsFolder + "portfolio-connection.xml" ) );
+        }
+
+        { // drivers
+            final String[] paths = manifest.getDriverPaths();
+            assertThat( Arrays.asList( paths ), hasItems( driversFolder + "books-driver-1.jar",
+                    driversFolder + "books-driver-2.jar", driversFolder + "portfolio-driver.jar" ) );
+        }
+
+        { // metadata
+            final String[] paths = manifest.getMetadataPaths();
+            assertThat( Arrays.asList( paths ),
+                    hasItems( metadataFolder + "firstDdl.ddl", metadataFolder + "secondDdl.ddl" ) );
+        }
+
+        { // resources
+            final String[] paths = manifest.getResourcePaths();
+            assertThat( Arrays.asList( paths ),
+                    hasItems( resourcesFolder + "firstResource.xml", resourcesFolder + "secondResource.xml" ) );
+        }
+
+        { // UDFs
+            final String[] paths = manifest.getUdfPaths();
+            assertThat( Arrays.asList( paths ), hasItem( udfsFolder + "secondUdf.jar" ) );
+        }
+
+        { // VDBs
+            final String[] paths = manifest.getVdbPaths();
+            assertThat( Arrays.asList( paths ),
+                    hasItems( vdbsFolder + "books-vdb.xml", vdbsFolder + "Portfolio-vdb.xml" ) );
+
+            final String[] dependencyPaths = manifest.getServiceVdb().getVdbPaths();
+            assertThat( Arrays.asList( dependencyPaths ), hasItem( vdbsFolder + "twitter-vdb.xml" ) );
         }
     }
 

--- a/sequencers/teiid-modeshape-sequencer-dataservice/src/test/resources/config/repo-config.json
+++ b/sequencers/teiid-modeshape-sequencer-dataservice/src/test/resources/config/repo-config.json
@@ -9,6 +9,10 @@
                 "classname" : "org.teiid.modeshape.sequencer.dataservice.DataServiceSequencer",
                 "pathExpressions" : [ "default://(*.zip)/jcr:content[@jcr:data] => /dataservices" ]
             },
+            "Teiid VDB Sequencer" : {
+                "classname" : "org.teiid.modeshape.sequencer.vdb.VdbDynamicSequencer",
+                "pathExpressions" : [ "default://(*-vdb.xml)/jcr:content[@jcr:data] => /vdbs" ]
+            },
             "Teiid Connection Sequencer" : {
                 "classname" : "org.teiid.modeshape.sequencer.dataservice.ConnectionSequencer",
                 "pathExpressions" : [ "default://(*-connection.xml)/jcr:content[@jcr:data] => /connections" ]

--- a/sequencers/teiid-modeshape-sequencer-dataservice/src/test/resources/vdbs/patients-vdb.xml
+++ b/sequencers/teiid-modeshape-sequencer-dataservice/src/test/resources/vdbs/patients-vdb.xml
@@ -1,0 +1,42 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<vdb
+    name="patients"
+    version="1"
+>
+
+    <description>Sample Dataservice for patient records</description>
+    <connection-type>BY_VERSION</connection-type>
+
+    <model
+        name="Patients"
+        type="VIRTUAL"
+    >
+        <description>Example Patient Service</description>
+        <metadata type="DDL">
+<![CDATA[CREATE VIEW TheServiceView (
+        id long,
+        firstName clob,
+        lastName clob,
+        gender clob,
+        age long,
+        currentSmoker boolean,
+        lastPrimaryCareVisit timestamp,
+        PRIMARY KEY(id)
+)
+AS
+SELECT id, firstName, lastName, gender, age, currentSmoker, lastPrimaryCareVisit FROM vdbwebtest.PATIENT;
+]]>
+
+        </metadata>
+    </model>
+    <model
+        name="PatientSource"
+        type="PHYSICAL"
+    >
+        <source
+            name="PatientSource"
+            translator-name="mysql5"
+            connection-jndi-name="java:/MySqlPatients" />
+    </model>
+
+</vdb>

--- a/sequencers/teiid-modeshape-sequencer-dataservice/src/test/resources/vdbs/product-view-vdb.xml
+++ b/sequencers/teiid-modeshape-sequencer-dataservice/src/test/resources/vdbs/product-view-vdb.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<vdb name="DynamicProducts" version="2">
+ 
+    <description>Product Dynamic VDB</description>    <!--
+      Setting to use connector supplied metadata. Can be "true" or "cached".
+      "true" will obtain metadata once for every launch of Teiid.
+      "cached" will save a file containing the metadata into
+      the deploy/<vdb name>/<vdb version/META-INF directory
+    -->
+    <property name="UseConnectorMetadata" value="true" />
+    
+    <model name="ProductsMySQL_Dynamic">
+        <!--
+            Each source represents a translator and data source. There are
+            pre-defined translators, or you can create one.
+        -->
+        <source name="jdbc" translator-name="mysql" connection-jndi-name="java:/ProductsMySQL"/>
+    </model>
+
+
+    <model name="ProductViews" type="VIRTUAL">
+        <metadata type="DDL"><![CDATA[
+            CREATE VIEW PRODUCT_VIEW (
+            ID string,
+            name string,
+            type string
+            ) AS SELECT INSTR_ID AS ID, NAME, TYPE
+                 FROM ProductsMySQL_Dynamic.PRODUCTS.PRODUCTDATA;
+        ]]> </metadata>
+    </model>
+    
+    <model name="ProductSummary" type="VIRTUAL">
+        <metadata type="DDL"><![CDATA[
+            CREATE VIEW PRODUCT_SUMMARY (
+            ID string,
+            name string,
+            type string
+            ) AS SELECT INSTR_ID AS ID, NAME, TYPE
+                 FROM ProductsMySQL_Dynamic.PRODUCTS.PRODUCTDATA;
+        ]]> </metadata>
+    </model>
+
+</vdb>

--- a/sequencers/teiid-modeshape-sequencer-dataservice/src/test/resources/vdbs/twitter-vdb.xml
+++ b/sequencers/teiid-modeshape-sequencer-dataservice/src/test/resources/vdbs/twitter-vdb.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<vdb name="twitter" version="1">
+ 
+    <description>Shows how to call Web Services</description>
+ 
+    <property name="UseConnectorMetadata" value="cached" />
+ 
+    <model name="twitter">
+        <source name="twitter" translator-name="rest" connection-jndi-name="java:/twitterDS"/>
+    </model>
+
+    <model name="twitterview" type="VIRTUAL">
+         <metadata type="DDL"><![CDATA[
+             CREATE VIRTUAL PROCEDURE getTweets(query varchar) RETURNS (created_on varchar(25), from_user varchar(25), to_user varchar(25),
+                 profile_image_url varchar(25), source varchar(25), text varchar(140)) AS
+                select tweet.* from
+                    (call twitter.invokeHTTP(action => 'GET', endpoint =>querystring('',query as "q"))) w,
+                    XMLTABLE('results' passing JSONTOXML('myxml', w.result) columns
+                    created_on string PATH 'created_at',
+                    from_user string PATH 'from_user',
+                    to_user string PATH 'to_user',
+                    profile_image_url string PATH 'profile_image_url',
+                    source string PATH 'source',
+                    text string PATH 'text') tweet;
+                CREATE VIEW Tweet AS select * FROM twitterview.getTweets;
+        ]]> </metadata>
+    </model>
+ 
+    <translator name="rest" type="ws">
+        <property name="DefaultBinding" value="HTTP"/>
+        <property name="DefaultServiceMode" value="MESSAGE"/>
+    </translator>
+</vdb>


### PR DESCRIPTION
- Data service VDBs will now always have a manifest entry name that ends with ``-vdb.xml`` when exported *if the entry name has not been explicitly set*
- Data service connections will now always have a manifest entry name that ends with ``-connection.xml`` when exported *if the entry name has not been explicitly set*