### PR TITLE
Fix  Non-compatible 1.6 code in DV branch

### DIFF
--- a/sequencers/teiid-modeshape-sequencer-dataservice/src/main/java/org/teiid/modeshape/sequencer/dataservice/DataServiceExporter.java
+++ b/sequencers/teiid-modeshape-sequencer-dataservice/src/main/java/org/teiid/modeshape/sequencer/dataservice/DataServiceExporter.java
@@ -22,24 +22,21 @@
 package org.teiid.modeshape.sequencer.dataservice;
 
 import static org.teiid.modeshape.sequencer.dataservice.DataServiceManifest.MANIFEST_ZIP_PATH;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.text.DateFormat;
-import java.text.SimpleDateFormat;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Calendar;
 import java.util.Date;
-import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
+
 import javax.jcr.Binary;
 import javax.jcr.Node;
 import javax.jcr.NodeIterator;
@@ -52,6 +49,7 @@ import javax.jcr.query.QueryResult;
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
+
 import org.modeshape.common.logging.Logger;
 import org.modeshape.common.util.StringUtil;
 import org.modeshape.jcr.api.JcrConstants;
@@ -79,7 +77,6 @@ public class DataServiceExporter extends AbstractExporter {
     public static final String RESULT_ENTRY_PATHS = "data-service-exporter.result-entry-paths";
 
     private static final String DEFAULT_CONNECTIONS_FOLDER = "connections/";
-    private static final SimpleDateFormat DEFAULT_DATE_FORMATTER = new SimpleDateFormat( DataServiceManifest.DATE_PATTERN );
     private static final String DEFAULT_DRIVERS_EXPORT_FOLDER = "drivers/";
     private static final String DEFAULT_METADATA_FOLDER = "metadata/";
     private static final String DEFAULT_RESOURCES_FOLDER = "resources/";
@@ -120,8 +117,7 @@ public class DataServiceExporter extends AbstractExporter {
 
         // lastModified is optional
         if ( dataService.hasProperty( DataVirtLexicon.DataService.LAST_MODIFIED ) ) {
-            final Date date = dataService.getProperty( DataVirtLexicon.DataService.LAST_MODIFIED ).getDate().getTime();
-            final LocalDateTime lastModified = date.toInstant().atZone( ZoneId.systemDefault() ).toLocalDateTime();
+            final Date lastModified = dataService.getProperty( DataVirtLexicon.DataService.LAST_MODIFIED ).getDate().getTime();
             manifest.setLastModified( lastModified );
         }
 
@@ -644,9 +640,9 @@ public class DataServiceExporter extends AbstractExporter {
             if ( manifest.getLastModified() != null ) {
                 xmlWriter.writeStartElement( DataVirtLexicon.DataServiceManifestId.LAST_MODIFIED );
 
-                final LocalDateTime modifiedDate = manifest.getLastModified();
-                final Calendar calendar = GregorianCalendar.from( modifiedDate.atZone( ZoneId.systemDefault() ) );
-                xmlWriter.writeCharacters( getDateFormatter( options ).format( calendar.getTime() ) );
+                final Date modifiedDate = manifest.getLastModified();
+                final String formattedDate = getDateFormatter( options ).format( modifiedDate );
+                xmlWriter.writeCharacters( formattedDate );
                 xmlWriter.writeEndElement();
             }
 
@@ -894,10 +890,10 @@ public class DataServiceExporter extends AbstractExporter {
 
     private DateFormat getDateFormatter( final Options options ) {
         assert ( options != null );
-        final Object temp = options.get( OptionName.DATE_FORMATTER, DEFAULT_DATE_FORMATTER );
+        final Object temp = options.get( OptionName.DATE_FORMATTER, DataServiceManifest.DATE_FORMATTER );
 
         if ( !( temp instanceof DateFormat ) ) {
-            return DEFAULT_DATE_FORMATTER;
+            return DataServiceManifest.DATE_FORMATTER;
         }
 
         return ( DateFormat )temp;

--- a/sequencers/teiid-modeshape-sequencer-dataservice/src/main/java/org/teiid/modeshape/sequencer/dataservice/DataServiceManifest.java
+++ b/sequencers/teiid-modeshape-sequencer-dataservice/src/main/java/org/teiid/modeshape/sequencer/dataservice/DataServiceManifest.java
@@ -22,13 +22,14 @@
 package org.teiid.modeshape.sequencer.dataservice;
 
 import java.io.InputStream;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeParseException;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Date;
 import java.util.Objects;
 import java.util.Properties;
+
 import org.modeshape.common.util.StringUtil;
 
 /**
@@ -49,7 +50,7 @@ public class DataServiceManifest implements VdbEntryContainer {
     /**
      * The date formatter for the last modified property.
      */
-    public static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern( DATE_PATTERN );
+    public static final SimpleDateFormat DATE_FORMATTER = new SimpleDateFormat( DATE_PATTERN );
 
     /**
      * The file name of the data service manifest. Value is {@value}.
@@ -69,10 +70,10 @@ public class DataServiceManifest implements VdbEntryContainer {
     /**
      * @param lastModifiedDate the string representation of the date being parsed (cannot be <code>null</code>)
      * @return the date (never <code>null</code>)
-     * @throws DateTimeParseException if the input cannot be parsed
+     * @throws ParseException if the input cannot be parsed
      */
-    public static LocalDateTime parse( final String lastModifiedDate ) throws DateTimeParseException {
-        return LocalDateTime.parse( Objects.requireNonNull( lastModifiedDate, "lastModifiedDate" ), DATE_FORMATTER );
+    public static Date parse( final String lastModifiedDate ) throws ParseException {
+        return DATE_FORMATTER.parse( lastModifiedDate );
     }
 
     static DataServiceManifest read( final InputStream stream ) throws Exception {
@@ -82,7 +83,7 @@ public class DataServiceManifest implements VdbEntryContainer {
     private final Collection< ConnectionEntry > connections = new ArrayList< ConnectionEntry >();
     private String description;
     private final Collection< DataServiceEntry > drivers = new ArrayList< DataServiceEntry >();
-    private LocalDateTime lastModified;
+    private Date lastModified;
     private final Collection< DataServiceEntry > metadata = new ArrayList< DataServiceEntry >();
     private String modifiedBy;
     private String name;
@@ -196,7 +197,7 @@ public class DataServiceManifest implements VdbEntryContainer {
     /**
      * @return the last time the manifest was modified (can be <code>null</code>)
      */
-    public LocalDateTime getLastModified() {
+    public Date getLastModified() {
         return this.lastModified;
     }
 
@@ -367,8 +368,8 @@ public class DataServiceManifest implements VdbEntryContainer {
     /**
      * @param lastModified the new last modified date with the nanoseconds stripped off (can be <code>null</code> or empty)
      */
-    public void setLastModified( final LocalDateTime lastModified ) {
-        this.lastModified = ( ( lastModified == null ) ? lastModified : lastModified.withNano( 0 ) );
+    public void setLastModified( final Date lastModified ) {
+        this.lastModified = lastModified;
     }
 
     /**

--- a/sequencers/teiid-modeshape-sequencer-dataservice/src/main/java/org/teiid/modeshape/sequencer/dataservice/DataServiceManifestReader.java
+++ b/sequencers/teiid-modeshape-sequencer-dataservice/src/main/java/org/teiid/modeshape/sequencer/dataservice/DataServiceManifestReader.java
@@ -26,9 +26,10 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.InputStream;
 import java.net.URL;
-import java.time.LocalDateTime;
+import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 import java.util.Stack;
@@ -170,8 +171,12 @@ public final class DataServiceManifestReader extends DefaultHandler {
         } else if ( DataVirtLexicon.DataServiceManifestId.DESCRIPTION.equals( localName ) ) {
             this.manifest.setDescription( this.description.toString() );
         } else if ( DataVirtLexicon.DataServiceManifestId.LAST_MODIFIED.equals( localName ) ) {
-            final LocalDateTime lastModifiedDate = DataServiceManifest.parse( this.lastModified.toString() );
-            this.manifest.setLastModified( lastModifiedDate );
+            try {
+                final Date lastModifiedDate = DataServiceManifest.parse( this.lastModified.toString() );
+                this.manifest.setLastModified( lastModifiedDate );
+            } catch ( final ParseException e ) {
+                LOGGER.error( TeiidI18n.errorParsingManifestLastModifiedDate, this.lastModified.toString() );
+            }
         } else if ( DataVirtLexicon.DataServiceManifestId.MODIFIED_BY.equals( localName ) ) {
             this.manifest.setModifiedBy( this.modifiedBy.toString() );
         } else if ( DataVirtLexicon.DataServiceManifestId.PROPERTY.equals( localName ) ) {

--- a/sequencers/teiid-modeshape-sequencer-dataservice/src/main/java/org/teiid/modeshape/sequencer/dataservice/DataServiceSequencer.java
+++ b/sequencers/teiid-modeshape-sequencer-dataservice/src/main/java/org/teiid/modeshape/sequencer/dataservice/DataServiceSequencer.java
@@ -22,20 +22,20 @@
 package org.teiid.modeshape.sequencer.dataservice;
 
 import static org.teiid.modeshape.sequencer.dataservice.DataServiceManifest.MANIFEST_ZIP_PATH;
+
 import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.util.Calendar;
-import java.util.GregorianCalendar;
+import java.util.Date;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
+
 import javax.jcr.Binary;
 import javax.jcr.NamespaceRegistry;
 import javax.jcr.Node;
@@ -44,6 +44,7 @@ import javax.jcr.Property;
 import javax.jcr.RepositoryException;
 import javax.jcr.Value;
 import javax.jcr.ValueFactory;
+
 import org.modeshape.common.annotation.ThreadSafe;
 import org.modeshape.common.logging.Logger;
 import org.modeshape.common.util.StringUtil;
@@ -465,8 +466,9 @@ public class DataServiceSequencer extends Sequencer {
 
         // last modified date
         if ( manifest.getLastModified() != null ) {
-            final LocalDateTime modifiedDate = manifest.getLastModified();
-            final Calendar calendar = GregorianCalendar.from( modifiedDate.atZone( ZoneId.systemDefault() ) );
+            final Date modifiedDate = manifest.getLastModified();
+            final Calendar calendar = Calendar.getInstance();
+            calendar.setTime( modifiedDate );
             outputNode.setProperty( DataVirtLexicon.DataService.LAST_MODIFIED, calendar );
         }
 

--- a/sequencers/teiid-modeshape-sequencer-dataservice/src/main/java/org/teiid/modeshape/sequencer/dataservice/TeiidI18n.java
+++ b/sequencers/teiid-modeshape-sequencer-dataservice/src/main/java/org/teiid/modeshape/sequencer/dataservice/TeiidI18n.java
@@ -34,6 +34,7 @@ public final class TeiidI18n {
     public static I18n errorExportingDataServiceManifest;
     public static I18n errorExportingDataServiceServiceVdb;
     public static I18n errorExportingDataServiceZip;
+    public static I18n errorParsingManifestLastModifiedDate;
     public static I18n noServiceVdbToExport;
     public static I18n unhandledErrorDuringDataServiceExport;
 

--- a/sequencers/teiid-modeshape-sequencer-dataservice/src/main/resources/org/teiid/modeshape/sequencer/dataservice/TeiidI18n.properties
+++ b/sequencers/teiid-modeshape-sequencer-dataservice/src/main/resources/org/teiid/modeshape/sequencer/dataservice/TeiidI18n.properties
@@ -25,6 +25,7 @@ errorExportingDataServiceFiles = Error exporting the data service file byte arra
 errorExportingDataServiceManifest = Error exporting the data service manifest
 errorExportingDataServiceServiceVdb = Error exporting the data service service VDB
 errorExportingDataServiceZip = Error exporting the data service zip file byte array
+errorParsingManifestLastModifiedDate - Unable to parse the manifest last modified date of "{0}"
 noServiceVdbToExport = There is no Service VDB to export
 unhandledErrorDuringDataServiceExport = An unhandled error exporting a data service
 

--- a/sequencers/teiid-modeshape-sequencer-dataservice/src/test/java/org/teiid/modeshape/sequencer/dataservice/DataServiceManifestTest.java
+++ b/sequencers/teiid-modeshape-sequencer-dataservice/src/test/java/org/teiid/modeshape/sequencer/dataservice/DataServiceManifestTest.java
@@ -27,15 +27,36 @@ import static org.hamcrest.core.IsNull.notNullValue;
 import static org.hamcrest.core.IsNull.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
+
 import java.io.InputStream;
 import java.net.URL;
-import java.time.LocalDateTime;
 import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Date;
+
 import org.junit.Test;
 import org.teiid.modeshape.sequencer.dataservice.DataServiceEntry.PublishPolicy;
 import org.xml.sax.SAXParseException;
 
 public final class DataServiceManifestTest {
+
+    private Date createDate( final int year,
+    		                     final int month,
+    		                     final int day,
+    		                     final int hour,
+    		                     final int minute,
+    		                     final int second ) {
+        final Calendar calendar = Calendar.getInstance();
+        calendar.set( Calendar.YEAR, year );
+        calendar.set( Calendar.MONTH, month );
+        calendar.set( Calendar.DAY_OF_MONTH, day );
+        calendar.set( Calendar.HOUR, hour );
+        calendar.set( Calendar.MINUTE, minute );
+        calendar.set( Calendar.SECOND, second );
+        calendar.set( Calendar.MILLISECOND, 0 );
+        
+        return calendar.getTime();
+    }
 
     private DataServiceEntry findEntry( final DataServiceEntry[] entries,
                                         final String path ) {
@@ -101,7 +122,7 @@ public final class DataServiceManifestTest {
         assertThat( manifest, is( notNullValue() ) );
         assertThat( manifest.getName(), is( "MyDataService" ) );
         assertThat( manifest.getDescription(), is( "This is my data service description" ) );
-        assertThat( manifest.getLastModified(), is( LocalDateTime.of( 2002, 5, 30, 9, 30, 10 ) ) );
+        assertThat( manifest.getLastModified(), is( createDate( 2002, 4, 30, 9, 30, 10 ) ) );
         assertThat( manifest.getModifiedBy(), is( "elvis" ) );
 
         assertThat( manifest.getProperties().size(), is( 1 ) );
@@ -193,7 +214,7 @@ public final class DataServiceManifestTest {
         assertThat( manifest, is( notNullValue() ) );
         assertThat( manifest.getName(), is( "DriverEntriesOnly" ) );
         assertThat( manifest.getDescription(), is( "This is my driver entries only description" ) );
-        assertThat( manifest.getLastModified(), is( LocalDateTime.of( 2002, 5, 30, 9, 30, 10 ) ) );
+        assertThat( manifest.getLastModified(), is( createDate( 2002, 4, 30, 9, 30, 10 ) ) );
         assertThat( manifest.getModifiedBy(), is( nullValue() ) );
 
         assertThat( manifest.getProperties().size(), is( 1 ) );
@@ -244,7 +265,7 @@ public final class DataServiceManifestTest {
         assertThat( manifest, is( notNullValue() ) );
         assertThat( manifest.getName(), is( "ResourceEntriesOnly" ) );
         assertThat( manifest.getDescription(), is( "This is my resources entries only description" ) );
-        assertThat( manifest.getLastModified(), is( LocalDateTime.of( 2002, 5, 30, 9, 30, 10 ) ) );
+        assertThat( manifest.getLastModified(), is( createDate( 2002, 4, 30, 9, 30, 10 ) ) );
         assertThat( manifest.getModifiedBy(), is( "elvis" ) );
 
         assertThat( manifest.getProperties().size(), is( 0 ) );
@@ -269,7 +290,7 @@ public final class DataServiceManifestTest {
         assertThat( manifest, is( notNullValue() ) );
         assertThat( manifest.getName(), is( "UdfEntriesOnly" ) );
         assertThat( manifest.getDescription(), is( nullValue() ) );
-        assertThat( manifest.getLastModified(), is( LocalDateTime.of( 2002, 5, 30, 9, 30, 10 ) ) );
+        assertThat( manifest.getLastModified(), is( createDate( 2002, 4, 30, 9, 30, 10 ) ) );
         assertThat( manifest.getModifiedBy(), is( nullValue() ) );
 
         assertThat( manifest.getProperties().size(), is( 3 ) );
@@ -297,7 +318,8 @@ public final class DataServiceManifestTest {
         assertThat( manifest, is( notNullValue() ) );
         assertThat( manifest.getName(), is( "VdbEntriesOnly" ) );
         assertThat( manifest.getDescription(), is( "This is my VDB entries only description" ) );
-        assertThat( manifest.getLastModified(), is( LocalDateTime.of( 2016, 10, 30, 10, 5, 33 ) ) );
+        
+        assertThat( manifest.getLastModified(), is( createDate( 2016, 9, 30, 10, 5, 33 ) ) );
         assertThat( manifest.getModifiedBy(), is( "sledge" ) );
 
         assertThat( manifest.getProperties().size(), is( 0 ) );

--- a/teiid-modeshape-core/src/main/java/org/teiid/modeshape/sequencer/Options.java
+++ b/teiid-modeshape-core/src/main/java/org/teiid/modeshape/sequencer/Options.java
@@ -177,7 +177,6 @@ public class Options {
     /**
      * Filters the properties that will be exported.
      */
-    @FunctionalInterface
     public interface PropertyFilter {
 
         /**


### PR DESCRIPTION
- converted all references to java.time classes back to java.util.Date.
- removed a 1.8 annotation.