### PR TITLE
Issue 43: Changed version numbers in pom files to be different from the dv-6.3.x

### DIFF
--- a/build/pom.xml
+++ b/build/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.jboss.teiid.modeshape</groupId>
         <artifactId>teiid-modeshape-parent</artifactId>
-        <version>0.0.1</version>
+        <version>0.0.2</version>
     </parent>
 
     <!-- ================================================================== -->

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.jboss.integration-platform</groupId>
         <artifactId>jboss-integration-platform-parent</artifactId>
-        <version>6.0.0.Final</version>
+        <version>6.0.0.CR30</version>
     </parent>
 
     <!-- ================================================================== -->
@@ -22,7 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
     <name>Teiid ModeShape</name>
     <packaging>pom</packaging>
-    <version>0.0.1</version>
+    <version>0.0.2</version>
 
     <!-- ================================================================== -->
     <!-- Properties -->

--- a/sequencers/pom.xml
+++ b/sequencers/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.jboss.teiid.modeshape</groupId>
         <artifactId>teiid-modeshape-parent</artifactId>
-        <version>0.0.1</version>
+        <version>0.0.2</version>
     </parent>
 
     <!-- ================================================================== -->

--- a/sequencers/teiid-modeshape-sequencer-dataservice/pom.xml
+++ b/sequencers/teiid-modeshape-sequencer-dataservice/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.jboss.teiid.modeshape</groupId>
         <artifactId>teiid-modeshape-sequencers</artifactId>
-        <version>0.0.1</version>
+        <version>0.0.2</version>
     </parent>
 
     <!-- ================================================================== -->

--- a/sequencers/teiid-modeshape-sequencer-ddl/pom.xml
+++ b/sequencers/teiid-modeshape-sequencer-ddl/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.jboss.teiid.modeshape</groupId>
         <artifactId>teiid-modeshape-sequencers</artifactId>
-        <version>0.0.1</version>
+        <version>0.0.2</version>
     </parent>
 
     <!-- ================================================================== -->

--- a/sequencers/teiid-modeshape-sequencer-vdb/pom.xml
+++ b/sequencers/teiid-modeshape-sequencer-vdb/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.jboss.teiid.modeshape</groupId>
         <artifactId>teiid-modeshape-sequencers</artifactId>
-        <version>0.0.1</version>
+        <version>0.0.2</version>
     </parent>
 
     <!-- ================================================================== -->

--- a/teiid-modeshape-core/pom.xml
+++ b/teiid-modeshape-core/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.jboss.teiid.modeshape</groupId>
         <artifactId>teiid-modeshape-parent</artifactId>
-        <version>0.0.1</version>
+        <version>0.0.2</version>
     </parent>
 
     <!-- ================================================================== -->

--- a/teiid-modeshape-utils/pom.xml
+++ b/teiid-modeshape-utils/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.jboss.teiid.modeshape</groupId>
         <artifactId>teiid-modeshape-parent</artifactId>
-        <version>0.0.1</version>
+        <version>0.0.2</version>
     </parent>
 
     <!-- ================================================================== -->


### PR DESCRIPTION
- changed version in poms to 0.0.2
- changed `jboss-integration-platform-parent` version in main pom to 6.0.0.CR30