### PR TITLE
Issue 45 - Correct Tests To Use 24-hour clock

### DIFF
--- a/sequencers/teiid-modeshape-sequencer-dataservice/src/test/java/org/teiid/modeshape/sequencer/dataservice/DataServiceManifestTest.java
+++ b/sequencers/teiid-modeshape-sequencer-dataservice/src/test/java/org/teiid/modeshape/sequencer/dataservice/DataServiceManifestTest.java
@@ -50,7 +50,7 @@ public final class DataServiceManifestTest {
         calendar.set( Calendar.YEAR, year );
         calendar.set( Calendar.MONTH, month );
         calendar.set( Calendar.DAY_OF_MONTH, day );
-        calendar.set( Calendar.HOUR, hour );
+        calendar.set( Calendar.HOUR_OF_DAY, hour );
         calendar.set( Calendar.MINUTE, minute );
         calendar.set( Calendar.SECOND, second );
         calendar.set( Calendar.MILLISECOND, 0 );


### PR DESCRIPTION
- Modified DataServiceManifestTest to use 24-hour clock when creating dates.