### PR TITLE
TEIIDTOOLS-186 changed to package all teiid-modeshape jars as modules

### DIFF
--- a/build/assembly/jboss-dist.xml
+++ b/build/assembly/jboss-dist.xml
@@ -18,7 +18,7 @@
             </includes>
 
             <binaries>
-                <outputDirectory>${jboss.kit.modules.location}/ddl/main</outputDirectory>
+                <outputDirectory>${jboss.kit.modules.location}/sequencer/ddl/main</outputDirectory>
                 <includeDependencies>false</includeDependencies>
                 <unpack>false</unpack>
             </binaries>
@@ -33,7 +33,35 @@
             </includes>
 
             <binaries>
-                <outputDirectory>${jboss.kit.modules.location}/vdb/main</outputDirectory>
+                <outputDirectory>${jboss.kit.modules.location}/sequencer/vdb/main</outputDirectory>
+                <includeDependencies>false</includeDependencies>
+                <unpack>false</unpack>
+            </binaries>
+        </moduleSet>
+
+        <moduleSet>
+            <useAllReactorProjects>true</useAllReactorProjects>
+
+            <includes>
+                <include>org.jboss.teiid.modeshape:teiid-modeshape-sequencer-dataservice</include>
+            </includes>
+
+            <binaries>
+                <outputDirectory>${jboss.kit.modules.location}/sequencer/dataservice/main</outputDirectory>
+                <includeDependencies>false</includeDependencies>
+                <unpack>false</unpack>
+            </binaries>
+        </moduleSet>
+
+        <moduleSet>
+            <useAllReactorProjects>true</useAllReactorProjects>
+
+            <includes>
+                <include>org.jboss.teiid.modeshape:teiid-modeshape-core</include>
+            </includes>
+
+            <binaries>
+                <outputDirectory>${jboss.kit.modules.location}/core/main</outputDirectory>
                 <includeDependencies>false</includeDependencies>
                 <unpack>false</unpack>
             </binaries>
@@ -43,8 +71,8 @@
     <fileSets>
         <!-- Teiid ModeShape DDL sequencer -->
         <fileSet>
-            <directory>kits/jboss/org/teiid/modeshape/sequencer/ddl/main</directory>
-            <outputDirectory>${jboss.kit.modules.location}/ddl/main</outputDirectory>
+            <directory>kits/jboss/org/jboss/teiid/modeshape/sequencer/ddl/main</directory>
+            <outputDirectory>${jboss.kit.modules.location}/sequencer/ddl/main</outputDirectory>
             <filtered>true</filtered>
             
             <includes>
@@ -54,8 +82,30 @@
 
         <!-- Teiid ModeShape VDB sequencer -->
         <fileSet>
-            <directory>kits/jboss/org/teiid/modeshape/sequencer/vdb/main</directory>
-            <outputDirectory>${jboss.kit.modules.location}/vdb/main</outputDirectory>
+            <directory>kits/jboss/org/jboss/teiid/modeshape/sequencer/vdb/main</directory>
+            <outputDirectory>${jboss.kit.modules.location}/sequencer/vdb/main</outputDirectory>
+            <filtered>true</filtered>
+
+            <includes>
+                <include>module.xml</include>
+            </includes>
+        </fileSet>
+
+        <!-- Teiid ModeShape Dataservice sequencer -->
+        <fileSet>
+            <directory>kits/jboss/org/jboss/teiid/modeshape/sequencer/dataservice/main</directory>
+            <outputDirectory>${jboss.kit.modules.location}/sequencer/dataservice/main</outputDirectory>
+            <filtered>true</filtered>
+
+            <includes>
+                <include>module.xml</include>
+            </includes>
+        </fileSet>
+
+        <!-- Teiid ModeShape Dataservice sequencer -->
+        <fileSet>
+            <directory>kits/jboss/org/jboss/teiid/modeshape/core/main</directory>
+            <outputDirectory>${jboss.kit.modules.location}/core/main</outputDirectory>
             <filtered>true</filtered>
 
             <includes>

--- a/build/kits/jboss/org/jboss/teiid/modeshape/core/main/module.xml
+++ b/build/kits/jboss/org/jboss/teiid/modeshape/core/main/module.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ ~ JBoss, Home of Professional Open Source.
+ ~ See the COPYRIGHT.txt file distributed with this work for information
+ ~ regarding copyright ownership.  Some portions may be licensed
+ ~ to Red Hat, Inc. under one or more contributor license agreements.
+ ~
+ ~ This library is free software; you can redistribute it and/or
+ ~ modify it under the terms of the GNU Lesser General Public
+ ~ License as published by the Free Software Foundation; either
+ ~ version 2.1 of the License, or (at your option) any later version.
+ ~
+ ~ This library is distributed in the hope that it will be useful,
+ ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ ~ Lesser General Public License for more details.
+ ~
+ ~ You should have received a copy of the GNU Lesser General Public
+ ~ License along with this library; if not, write to the Free Software
+ ~ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ ~ 02110-1301 USA.
+-->
+<module xmlns="urn:jboss:module:1.2" name="org.jboss.teiid.modeshape.core">
+    <resources>
+        <resource-root path="teiid-modeshape-core-${project.version}.jar" />
+    </resources>
+
+    <dependencies>
+        <module name="org.modeshape.jcr.api"/>
+        <module name="org.modeshape.common"/>
+    </dependencies>
+</module>

--- a/build/kits/jboss/org/jboss/teiid/modeshape/sequencer/dataservice/main/module.xml
+++ b/build/kits/jboss/org/jboss/teiid/modeshape/sequencer/dataservice/main/module.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ ~ JBoss, Home of Professional Open Source.
+ ~ See the COPYRIGHT.txt file distributed with this work for information
+ ~ regarding copyright ownership.  Some portions may be licensed
+ ~ to Red Hat, Inc. under one or more contributor license agreements.
+ ~
+ ~ This library is free software; you can redistribute it and/or
+ ~ modify it under the terms of the GNU Lesser General Public
+ ~ License as published by the Free Software Foundation; either
+ ~ version 2.1 of the License, or (at your option) any later version.
+ ~
+ ~ This library is distributed in the hope that it will be useful,
+ ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ ~ Lesser General Public License for more details.
+ ~
+ ~ You should have received a copy of the GNU Lesser General Public
+ ~ License along with this library; if not, write to the Free Software
+ ~ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ ~ 02110-1301 USA.
+-->
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.teiid.modeshape.sequencer.dataservice">
+    <resources>
+        <resource-root path="teiid-modeshape-sequencer-dataservice-${project.version}.jar" />
+    </resources>
+
+    <dependencies>
+        <module name="org.modeshape.jcr.api"/>
+        <module name="org.modeshape.common"/>
+    </dependencies>
+</module>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <!-- ================================================================== -->
     <properties>
         <hamcrest.version>1.3</hamcrest.version>
-        <jboss.kit.modules.location>modules/system/layers/dv/org/jboss/teiid/modeshape/sequencer</jboss.kit.modules.location>
+        <jboss.kit.modules.location>modules/system/layers/dv/org/jboss/teiid/modeshape/</jboss.kit.modules.location>
         <jboss.scripts.location>cli-scripts</jboss.scripts.location>
         <jboss.vdb.location>dataVirtualization/vdb</jboss.vdb.location>
         <junit.version>4.12</junit.version>


### PR DESCRIPTION
TEIIDTOOLS-186 changed to package all teiid-modeshape jars as modules in the jboss-dist zip

This also needs to pushed to the dv-6.4.x branch.